### PR TITLE
Enhance Dependabot settings for dependencies and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       - dependency-type: "all" # update both direct and indirect dependencies
     ignore:
       - dependency-name: "django"
-        versions: ["<3.2"] # example: ignore Django versions below 3.2
+        versions: ["<3.2"] # Ignore Django versions below 3.2
     assignees:
       - "canstralian"
     reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,50 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
+
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/" # Root directory for Python dependencies
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: "all" # update both direct and indirect dependencies
+    ignore:
+      - dependency-name: "django"
+        versions: ["<3.2"] # example: ignore Django versions below 3.2
+    assignees:
+      - "canstralian"
+    reviewers:
+      - "canstralian"
+    commit-message:
+      prefix: "build(deps):"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "auto-update"
+    rebase-strategy: "auto"
+    pull-request-branch-name:
+      separator: "-"
+
+# Enable security updates (GitHub Advisory Database)
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of GitHub Actions workflows
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    assignees:
+      - "canstralian"
+    reviewers:
+      - "canstralian"
+    labels:
+      - "github-actions"
+      - "auto-update"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    rebase-strategy: "auto"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,6 @@ updates:
       - "github-actions"
       - "auto-update"
     commit-message:
-      prefix: "ci"
+      prefix: "ci:"
       include: "scope"
     rebase-strategy: "auto"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to provide more granular control over dependency and GitHub Actions updates. The changes introduce scheduled updates, more detailed rules for dependency management, and improved automation for pull requests.

Configuration improvements for Python dependencies:

* Added a weekly update schedule (Mondays at 06:00 UTC), limited open PRs to 5, and specified rules to allow all dependency types, ignore Django versions below 3.2, and assign/review PRs to "canstralian". Pull requests now include custom commit message prefixes, labels, and use an automatic rebase strategy.

Automation for GitHub Actions updates:

* Enabled weekly security updates for GitHub Actions workflows with similar scheduling, assignment, labeling, and commit message conventions as the Python ecosystem. The open PR limit is set to 3.Updated Dependabot configuration for Python and GitHub Actions.