### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/huggingface-deploy.yml
+++ b/.github/workflows/huggingface-deploy.yml
@@ -1,4 +1,6 @@
 name: Hugging Face Model CI/CD
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/canstralian/CodeTuneStudio/security/code-scanning/5](https://github.com/canstralian/CodeTuneStudio/security/code-scanning/5)

**General approach:**  
Add an explicit `permissions` block in the workflow YAML file. This can be set at the workflow (top) level (applies to all jobs unless overridden) or for each job. The minimal safe default is `contents: read`, as recommended.

**Best way to fix:**  
Since neither the build nor deploy jobs appear to require write-level permissions (they are running tests, installing dependencies, logging into Hugging Face using a token, and uploading a model to Hugging Face—not pushing code or creating PRs), add `permissions: contents: read` near the top of the workflow file, just after the workflow `name` and before the `on:` key. This explicitly restricts the GITHUB_TOKEN to read-only permissions on repository contents.

**Where to change:**  
- Edit `.github/workflows/huggingface-deploy.yml`
- Insert the `permissions:` block on a new line after `name: Hugging Face Model CI/CD`

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
