### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/canstralian/CodeTuneStudio/security/code-scanning/6](https://github.com/canstralian/CodeTuneStudio/security/code-scanning/6)

To fix this, **add an explicit `permissions` block to the workflow**, specifying the least privilege required. For this workflow, read-only access to repository contents is sufficient (needed by `actions/checkout@v4`). This is done by adding the following near the top level of the workflow (recommended to put after the `name` and before/after `on:`):

```yaml
permissions:
  contents: read
```

Alternatively, `permissions` can go under the job, but putting it at the workflow root ensures all jobs inherit it by default.

**Edit needed:**  
In `.github/workflows/ci.yml`, add the `permissions` block after the `name:` line (and before `on:` or jobs), or immediately after the `on:` block.

**No new imports or method definitions are needed.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
