### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/huggingface-deploy.yml
+++ b/.github/workflows/huggingface-deploy.yml
@@ -1,4 +1,6 @@
 name: Hugging Face Model CI/CD
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/canstralian/CodeTuneStudio/security/code-scanning/1](https://github.com/canstralian/CodeTuneStudio/security/code-scanning/1)

To fix the problem, add an explicit `permissions:` block to the workflow, set at the workflow or job level. Since neither job requires write access to repository contents (they do not push code or manage PRs/issues using GitHub's API), the best practice is to set `contents: read`, which provides the minimum necessary permissions for most CI operations. Place the `permissions:` block at the workflow level just after the `name:` line (and before `on:`), so both jobs inherit the same reduced permission level, unless individual jobs require a different setting. This change is non-intrusive and does not affect existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
