### PR TITLE
Add Copilot and Codex configuration guide

### DIFF
--- a/docs/copilot-codex-guide.md
+++ b/docs/copilot-codex-guide.md
@@ -1,70 +1,81 @@
-# GitHub Copilot and Codex Configuration Guide for the Trading Bot Swarm Ecosystem
+# GitHub Copilot and Codex Configuration Guide for the Trading Bot Swarm
 
 ## Purpose and Scope
-This guide defines how GitHub Copilot and Codex act as disciplined pair programmers across the Trading Bot Swarm ecosystem. It documents the behavioral rules, tooling configuration, automation workflows, and validation steps that keep code quality, security, and reliability consistently high. Copilot and Codex should always reinforce project conventions rather than invent their own.
+- Standardize how GitHub Copilot and Codex are configured and used as pair programmers.
+- Enforce consistent behavior, code quality, security, and automation across all Trading Bot Swarm services.
+- Apply to all contributors, CI jobs, and automation pipelines interfacing with the codebase.
+
+## Role of Copilot as Pair Programmer
+- Copilot acts as a suggestion engine, not an autonomous committer.
+- Follow strict behavioral rules: no secret exfiltration, prefer existing patterns, avoid generating credentials, and suggest changes in the smallest reviewable increments.
+- Suggestions must respect repository conventions (lint, formatting, typing, async patterns) and never bypass security controls.
 
 ## Configuration Overview
-- **Testing and linting**: Run the full lint and test suite for any code change; documentation-only changes may skip execution but still require a quick format check. Favor `pytest` and project-standard linters (e.g., Ruff/Flake8/ESLint) with strict error thresholds.
-- **Code style**: Enforce Black/Prettier-style formatting, typed Python where applicable (mypy/pyright), and explicit imports. Avoid try/except around imports. Prefer small, composable functions and consistent naming aligned with existing modules.
-- **Async patterns**: Use `asyncio` primitives, `async with` for resources, and cancel tasks cleanly. Never block the event loop with synchronous I/O; prefer `await`able calls and timeouts.
-- **Security defaults**: Deny-by-default network calls, sanitize inputs, validate schemas, and keep secrets out of logs. Require dependency pinning and vulnerability scanning before merges. Enable branch protection and required status checks.
-- **Logging and observability**: Use structured logging (JSON-friendly) with correlation IDs. Emit metrics for critical paths and instrument traces for long-lived async tasks. Avoid sensitive payloads in logs.
-- **CI/CD integration**: Require lint, type-check, and test jobs to pass before merge. Enforce review approvals and signed commits for release branches. Publish artifacts only after quality gates succeed.
-- **Version control**: Use conventional commits, short-lived branches, and rebase over merge when possible. Keep PRs small, labeled with scope, and linked to issues. Auto-close stale branches after review or inactivity.
+- **Testing**: Default to running unit and integration tests relevant to touched modules; favor `pytest -m "not e2e"` for fast validation and full suites in CI.
+- **Linting/Formatting**: Enforce `ruff`/`flake8`, `black`, and `isort`/`ruff format` as configured. Reject suggestions that ignore lint rules.
+- **Code Style**: Honor type hints, short functions, explicit returns, and clear docstrings. Prefer dependency injection and minimize global state.
+- **Async Patterns**: Use `asyncio`/`trio` friendly code; avoid blocking calls in async contexts; wrap network I/O with timeouts and retries.
+- **Security Defaults**: Require parameterized queries, secret management via environment/secret stores, input validation, CSRF protection in web surfaces, and least-privilege IAM. Deny suggestions that introduce plaintext secrets or weaken authz/authn.
+- **Logging & Observability**: Standardize on structured logging with request IDs/trace IDs, emit metrics for critical paths, and propagate OpenTelemetry context when available.
+- **CI/CD Integration**: Ensure generated changes include test/lint hooks, reusable workflows, and status checks. Prefer idempotent scripts.
+- **Version Control**: Encourage small, atomic commits with descriptive messages, signed tags for releases, and conventional commit prefixes when possible.
 
-## Custom Instruction Behavior for Codex and Copilot
+## Custom Instruction Behavior (Copilot & Codex)
+- Enforce running tests/linters for code changes; documentation-only changes may skip.
+- Require reviewable diffs with comments explaining risky changes.
+- Prefer existing utility functions before introducing new dependencies.
 
-### Behavioral Rules (examples)
-- Treat Copilot as a guardrailed assistant: propose changes that align with project patterns, add tests for new logic, and avoid speculative refactors.
-- Prefer clarity over brevity: include docstrings and type hints, and add comments around risk boundaries (e.g., external API calls, trading algorithms).
-- Never commit secrets, credentials, or example keys. Mask sensitive values in logs and configs.
-- For code changes, always run or recommend running tests and linters; skip automation only for documentation-only edits.
+### Example Behavioral Rules
+- Reject code that accesses network outside allowed endpoints.
+- Require feature flags for experimental paths.
+- Prefer configuration via environment variables and `.env` templates.
+- Do not propose direct database migrations without validations and backups.
 
-### Conceptual Custom Instructions (YAML)
+### Conceptual YAML for Custom Instructions
 ```yaml
 copilot:
-  role: "pair-programmer with strict guardrails"
-  must_do:
-    - follow repository coding standards and async guidelines
-    - suggest tests and lint checks for any code change
-    - minimize external calls; use mocks in tests
-    - keep prompts and completions free of secrets
-  must_not_do:
-    - generate untyped code when the module is typed
-    - auto-create large refactors without explicit request
-    - bypass code review or CI requirements
-  reviewer_notes:
-    - highlight missing tests, logging, or security validations
-    - flag blocking operations inside async flows
+  role: pair-programmer
+  required_behaviors:
+    - respect_existing_patterns: true
+    - run_tests_before_commit: true
+    - run_linters_before_commit: true
+    - skip_checks_for_docs_only: true
+    - prefer_existing_utils: true
+    - no_plaintext_secrets: true
+    - enforce_timeouts_for_io: true
+  review_prompts:
+    - "Have you run pytest and lint for code changes?"
+    - "Did you reuse an existing helper instead of adding a new dependency?"
+    - "Are you avoiding blocking calls in async contexts?"
+  prohibited:
+    - generating_credentials
+    - disabling_security_controls
+    - committing_without_review
 
 codex:
-  role: "automation copilot for CI/CD and maintenance"
-  must_do:
-    - enforce quality gates (lint, type, test) on code diffs
-    - ignore documentation-only changes for heavy test runs
-    - recommend dependency and security updates regularly
-  must_not_do:
-    - push releases without passing gates
-    - downgrade security settings for speed
+  role: automation_guardrail
+  checks:
+    - verify_tests_executed: true
+    - verify_linters_executed: true
+    - ensure_docs_only_changes_skip_checks: true
+    - require_changelog_or_release_notes_for_features: true
+  output_expectations:
+    - short_diff_summaries
+    - inline_security_callouts
 ```
 
-## GitHub Workflow: Lint and Test Automation
-Trigger on pull requests to `main` and on pushes to release branches. Use `paths-ignore` to skip docs-only changes.
+## GitHub Workflow Example: Lint and Test Automation
+Trigger on pull requests, pushes to `main`, and schedule for nightly assurance.
 
 ```yaml
 name: quality-gate
-
 on:
   pull_request:
-    branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    branches: [main, develop]
   push:
-    branches: ["release/*"]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    branches: [main]
+  schedule:
+    - cron: "0 3 * * *"  # nightly
 
 jobs:
   lint-and-test:
@@ -72,17 +83,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: '3.11'
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
       - name: Lint
         run: |
           ruff check .
-          mypy .
-      - name: Test
-        run: pytest --maxfail=1 --disable-warnings -q
+          black --check .
+      - name: Tests
+        run: |
+          pytest -m "not e2e" --maxfail=1 --disable-warnings -q
+      - name: Upload coverage
+        if: success()
+        uses: codecov/codecov-action@v4
 ```
 
 ## Best-Practice Workflows
@@ -90,7 +107,6 @@ jobs:
 ### Semantic Release and Version Tagging
 ```yaml
 name: semantic-release
-
 on:
   push:
     branches: [main]
@@ -98,57 +114,68 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: '20'
       - run: npm ci
-      - name: Semantic Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+      - run: npx semantic-release
 ```
+- Require conventional commits for automatic changelog and tag generation.
+- Protect `main` with required checks before tags are created.
 
 ### Security and Dependency Scanning
 ```yaml
 name: security-scan
-
 on:
+  pull_request:
+  push:
+    branches: [main]
   schedule:
     - cron: "0 6 * * 1"  # weekly
-  workflow_dispatch: {}
 
 jobs:
-  dependencies:
+  deps-and-security:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Python dependency audit
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+      - name: Vulnerability scan
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - name: CodeQL analyze
+        uses: github/codeql-action/analyze@v3
+      - name: Pip audit
         run: pip install pip-audit && pip-audit
-
-  codeql:
-    uses: github/codeql-action/.github/workflows/codeql.yml@v3
-    secrets: inherit
 ```
 
 ## Contributor Guidelines
-- Propose changes via issues and scoped branches; use conventional commit messages.
-- Every PR must show passing lint/type/test checks and include risk-aware notes for trading logic changes.
-- Reviewers check for test coverage, logging/observability hooks, secure defaults, and adherence to async and style rules.
-- Validation includes CI results, manual verification of critical paths, and ensuring no secrets or credentials are present.
+- Propose changes via draft PRs with linked issues and clear scope statements.
+- Must include: tests, lint compliance, security impact notes, and rollback plan for risky changes.
+- Review criteria: correctness, performance impact, observability, security posture, and alignment with style guides.
+- Validation process: pre-commit hooks, CI quality gate, manual code review, and release checklist with sign-off.
 
-## Troubleshooting and Optimization
-- **Flaky tests**: isolate with `pytest -k` selectors; add retries only at the fixture level and document root causes.
-- **Lint failures**: run formatters locally (`black`, `ruff`, `prettier`) and align imports. Enable editor integrations to auto-fix on save.
-- **Slow CI**: cache dependencies, parallelize test matrices, and use `paths-ignore` to skip non-code changes.
-- **Async issues**: check for blocking calls, missing awaits, and unhandled cancellations; add timeouts and structured logging to trace flows.
-- **Security alerts**: rotate credentials immediately, upgrade affected packages, and document mitigations in the changelog.
+## Troubleshooting and Optimization Tips
+- **Copilot noise**: tighten context by selecting relevant files and add inline TODOs for focus.
+- **Async timeouts**: set defaults (e.g., 5s) and expose overrides via config.
+- **Flaky tests**: isolate external dependencies, add retries/backoff, and tag as `@flaky` until fixed.
+- **Dependency conflicts**: prefer `pip-compile` with explicit Python version pins and hash-locked artifacts.
+- **Performance hotspots**: add profiling hooks (`cProfile`, `py-spy`), cache heavy computations, and instrument metrics.
 
 ## Maintenance Schedule
-- Review this guide quarterly or whenever CI/CD, security posture, or coding standards change.
-- Keep workflow versions and action pins current; audit third-party actions for provenance.
-- Archive superseded instructions and link to the latest guidance to avoid drift across trading-bot repositories.
+- Quarterly review of Copilot/Codex instruction set and workflow YAMLs to reflect new stack defaults.
+- Post-incident updates within 48 hours to capture new guardrails or fixes.
+- Align guide revisions with major release milestones and dependency baseline updates.
 
 ## Closing Note
-Standardizing excellence in Copilot and Codex behavior strengthens the reliability, performance, and safety of the Trading Bot Swarm ecosystem.
+Standardizing these practices strengthens reliability, performance, and safety across the Trading Bot Swarm, ensuring every contribution upholds excellence.


### PR DESCRIPTION
## Summary
- add a comprehensive GitHub Copilot and Codex configuration guide for the Trading Bot Swarm
- outline testing, linting, security, and CI/CD expectations with example workflow YAML
- include contributor guidelines, troubleshooting tips, and maintenance cadence for the guide

## Testing
- Not applicable (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b8753dfc8332b784a48594684864)