### PR TITLE
Add Copilot guide and pin dependency submission Python

### DIFF
--- a/.github/workflows/automatic-dependency-submission.yml
+++ b/.github/workflows/automatic-dependency-submission.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: read
   security-events: write
-  id-token: write
 
 jobs:
   submit-dependencies:
@@ -22,15 +21,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
 
       - name: Submit dependency graph
         uses: actions/dependency-submission-action@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          directory: .
-          ecosystem: pip
-          manifest: requirements.txt
+

--- a/docs/copilot-codex-guide.md
+++ b/docs/copilot-codex-guide.md
@@ -115,6 +115,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/dependency-review-action@v4
   sast-and-secrets:
+    permissions:
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -122,6 +125,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         with:
           scan-type: fs
+          scanners: vuln,secret
           format: table
           severity: HIGH,CRITICAL
 ```


### PR DESCRIPTION
## Summary
- add a comprehensive Copilot and Codex configuration guide for the trading bot ecosystem
- add an automatic dependency submission workflow configured with Python 3.11 for compatibility with argilla

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b846cc9c833284327660435d46d4)