### PR TITLE
Fix OpenAI analyzer temperature argument duplication

### DIFF
--- a/plugins/openai_code_analyzer.py
+++ b/plugins/openai_code_analyzer.py
@@ -129,10 +129,9 @@ class OpenAICodeAnalyzerTool(AgentTool):
             try:
                 self._apply_rate_limiting()
 
-                response = self.client.chat.completions.create(
-                    model=self.model_name,
-                    temperature=self.temperature,
-                    messages=[
+                request_params = {
+                    "model": self.model_name,
+                    "messages": [
                         {
                             "role": "system",
                             "content": (
@@ -147,7 +146,10 @@ class OpenAICodeAnalyzerTool(AgentTool):
                         },
                         {"role": "user", "content": f"Analyze this code:\n\n{code}"},
                     ],
-                )
+                    "temperature": self.temperature,
+                }
+
+                response = self.client.chat.completions.create(**request_params)
 
                 return {
                     "analysis": response.choices[0].message.content,


### PR DESCRIPTION
## Summary
- refactor OpenAI chat completion payload construction to ensure `temperature` is only provided once
- preserve analyzer request structure while preventing duplicate keyword errors during import

## Testing
- python -m py_compile plugins/openai_code_analyzer.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926e056e7ac8332b169d0fed6d35f00)