### PR TITLE
docs: refine GitHub Copilot & Codex guide wording and workflow steps

### DIFF
--- a/docs/github-copilot-codex-guide.md
+++ b/docs/github-copilot-codex-guide.md
@@ -1,10 +1,15 @@
 # Comprehensive GitHub Copilot and Codex Guide for Trading Bot Swarm
 
 ## Purpose and Scope
-- Establish a single, authoritative playbook for configuring GitHub Copilot and Codex across the Trading Bot Swarm ecosystem.
-- Treat Copilot as a disciplined pair programmer with strict behavioral rules: it can propose changes, but humans own acceptance, review, and deployment decisions.
-- Apply these standards to application code, infra-as-code, data/ML pipelines, automation scripts, and operational runbooks. Documentation-only changes may skip test execution but must still follow review and linting rules.
-- Promote consistency, code quality, and secure automation to protect trading reliability and safety.
+- Establish a single, authoritative playbook for configuring GitHub Copilot and Codex
+  across the Trading Bot Swarm ecosystem.
+- Treat Copilot as a disciplined pair programmer with strict behavioral rules: it can
+  propose changes, but humans own acceptance, review, and deployment decisions.
+- Apply these standards to application code, infra-as-code, data/ML pipelines,
+  automation scripts, and operational runbooks. Documentation-only changes may skip
+  runtime test execution but must still follow review and linting rules.
+- Promote consistency, code quality, and secure automation to protect trading
+  reliability and safety across every service in the swarm.
 
 ## Configuration Overview
 - **Testing**
@@ -46,6 +51,7 @@
   - Surface required secrets/configuration and how to load them securely.
   - Enforce async-safe patterns and structured logging.
   - Provide minimal repro steps when diagnosing failures.
+  - Skip runtime tests for documentation-only edits; do not skip linting or review.
 - **Conceptual Custom Instructions (YAML)**
 ```yaml
 copilot:
@@ -75,8 +81,11 @@ codex:
 ```
 
 ## GitHub Workflow Example: Lint & Test Automation
-- **Triggers:** `pull_request` (opened, synchronize, reopened), `push` to protected branches, and manual `workflow_dispatch`. Ignore pure documentation paths for runtime steps.
-- **Quality Gate Job:**
+- **Triggers:** `pull_request` (opened, synchronize, reopened), `push` to protected
+  branches, and manual `workflow_dispatch`. Ignore documentation-only paths for
+  runtime steps.
+- **Quality Gate Job Steps:** Checkout, runtime setup, dependency install, lint,
+  type-check, unit tests, and coverage upload.
 ```yaml
 name: lint-and-test
 
@@ -201,4 +210,3 @@ jobs:
 
 ## Closing Note
 Standardize for excellence: by following these Copilot and Codex guardrails, contributors strengthen the reliability, performance, and safety of the Trading Bot Swarm ecosystem while keeping automation consistent and auditable.
-


### PR DESCRIPTION
### Motivation
- Clarify the scope and behavior expectations for GitHub Copilot and Codex across the Trading Bot Swarm ecosystem.
- Emphasize that documentation-only edits may skip runtime tests while still requiring linting and human review.
- Make the CI quality-gate steps and workflow trigger language clearer and easier to follow.
- Improve phrasing to better align with security, observability, and automation guardrails.

### Description
- Updated `docs/github-copilot-codex-guide.md` to reflow and tighten the `Purpose and Scope` section for clarity across services.
- Made explicit that documentation-only changes may skip runtime tests but must not skip linting or code review (`Skip runtime tests for documentation-only edits; do not skip linting or review`).
- Clarified GitHub Actions trigger wording and summarized the quality gate steps as: checkout, runtime setup, dependency install, lint, type-check, unit tests, and coverage upload.
- Minor wording and formatting improvements throughout the guide to better surface security and CI/CD expectations.

### Testing
- Ran `pytest` — collection failed with `ModuleNotFoundError` during test import (missing top-level modules such as `plugins`, `core`, `db_check`, `manage`), so the test run did not complete successfully.
- Ran `ruff check .` — linting reported a large number of existing violations (~906 errors) including logging f-string issues, missing type annotations, and other style points; many are fixable but the repo currently fails lint checks.
- No runtime behavioral changes or codepaths were modified; changes are documentation-only and intended to be safe to merge following the repo's review/linting policies.
- Recommend running `ruff format .`, `ruff check --fix .`, and a full `pytest` in the project environment (with PYTHONPATH set so tests can import project modules) before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694514e1acf8833283a616b87e746ff2)