### PR TITLE
Pin anthropic requirement to messages-capable release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,5 @@ argilla==2.8.0
 
 # AI providers
 openai>=1.0.0
-anthropic>=0.45.2
+# Claude Messages API requires the modern Anthropics client used by the plugins.
+anthropic>=0.45.2,<1


### PR DESCRIPTION
## Summary
- require the anthropic client version aligned with Claude Messages API usage
- document the compatibility expectation directly in requirements

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69259409cee48332be0c8b440c0a33c2)