### PR TITLE
Restore corrupted static-analysis modules, add SDK fallbacks, and fix workflow validator

### DIFF
--- a/core/parser/__init__.py
+++ b/core/parser/__init__.py
@@ -1,2 +1,3 @@
-ZnJvbSAucy5lbmdpbmUgaW1wb3J0IHBhcnNlX2NvZGUsIExhbmd1YWdlCgpfX2FsbF9fID0gWyJw
-YXJzZV9jb2RlIiwgIkxhbmd1YWdlIl0K
+from core.parser.engine import Language, parse_code
+
+__all__ = ["Language", "parse_code"]

--- a/core/parser/engine.py
+++ b/core/parser/engine.py
@@ -44,7 +44,17 @@ def detect_language(code: str, filename: str | None = None) -> Language:
 
 
 def parse_python(code: str) -> ParseResult:
-    """Parse Python code into an AST representation."""
+    """
+    Parse Python source code and produce a ParseResult summarizing the parsed AST or syntax errors.
+    
+    On successful parse, `ast_data` will contain a summary with `"type": "Module"` and a `"body_count"` integer. If a SyntaxError occurs, the result has `success=False`, `ast_data={}`, and `errors` containing a ParseError with `message`, `line`, `column`, and `source` extracted from the SyntaxError.
+    
+    Parameters:
+    	code (str): Python source code to parse.
+    
+    Returns:
+    	ParseResult: A ParseResult for Language.PYTHON containing either `ast_data` (on success) or `errors` and `success=False` (on syntax error).
+    """
     try:
         tree = ast.parse(code)
         ast_data = {"type": "Module", "body_count": len(tree.body)}
@@ -65,7 +75,14 @@ def parse_python(code: str) -> ParseResult:
 
 
 def parse_javascript(code: str) -> ParseResult:
-    """Parse JavaScript code using pyjsparser when available."""
+    """
+    Parse JavaScript source into a ParseResult using the installed pyjsparser.
+    
+    On success the returned ParseResult contains the parser's AST-like dictionary in `ast_data`. If pyjsparser is not available or parsing fails, the returned ParseResult has `ast_data` empty, `errors` containing one or more ParseError entries describing the problem, and `success` set to False.
+        
+    Returns:
+        ParseResult: Parsed AST in `ast_data` on success; on failure `errors` contains ParseError(s) and `success` is False.
+    """
     if not js_parser:
         return ParseResult(
             language=Language.JAVASCRIPT,
@@ -87,7 +104,18 @@ def parse_javascript(code: str) -> ParseResult:
 
 
 def parse_code(code: str, filename: str | None = None) -> ParseResult:
-    """Primary API for the Code Parsing Pipeline."""
+    """
+    Detect the source language and parse the provided code, returning a ParseResult describing the outcome.
+    
+    If a language parser is available for the detected language, parsing is performed and its result is returned. If no parser is implemented for the detected language, the returned ParseResult indicates failure and includes an explanatory ParseError.
+    
+    Parameters:
+        code (str): Source code to parse.
+        filename (str | None): Optional filename used to help detect the language (affects heuristics); may be None.
+    
+    Returns:
+        ParseResult: Object containing the detected language, any AST or summary data, a list of ParseError objects when parsing failed, and a boolean `success` flag.
+    """
     lang = detect_language(code, filename)
 
     if lang == Language.PYTHON:
@@ -105,7 +133,21 @@ def parse_code(code: str, filename: str | None = None) -> ParseResult:
 
 
 def parse_code_to_json(code: str, filename: str | None = None) -> str:
-    """Serialize a parse result for CLI-style callers."""
+    """
+    Serialize the parser output into a CLI-friendly JSON string.
+    
+    Returns a JSON string with the following keys:
+    - "language": the language name
+    - "ast_data": parser AST or summary data
+    - "errors": a list of error objects (each represented as a dict with the ParseError fields)
+    - "success": boolean parse success flag
+    
+    Parameters:
+        filename (str | None): Optional filename used to assist language detection; may be None.
+    
+    Returns:
+        str: The serialized JSON representation described above.
+    """
     result = parse_code(code, filename)
     return json.dumps(
         {

--- a/core/parser/engine.py
+++ b/core/parser/engine.py
@@ -1,51 +1,117 @@
-aW1wb3J0IGFzdAppbXBvcnQganNvbgpmcm9tIHR5cGluZyBpbXBvcnQgT3B0aW9uYWwsIEFueSwg
-RGljdApmcm9tIC5zLnR5cGVzIGltcG9ydCBMYW5ndWFnZSwgUGFyc2VSZXN1bHQsIFBhcnNlRXJy
-b3IKCnRyeToKICAgIGZyb20gcHlqc3BhcnNlciBpbXBvcnQgUHlKc1BhcnNlcgogICAganNfcGFy
-c2VyID0gUHlKc1BhcnNlcigpCmV4Y2VwdCBJbXBvcnRFcnJvcjoKICAgIGpzX3BhcnNlciA9IE5v
-bmUKCmRlZiBkZXRlY3RfbGFuZ3VhZ2UoY29kZTogc3RyLCBmaWxlbmFtZTogT3B0aW9uYWxbc3Ry
-XSA9IE5vbmUpIC0+IExhbmd1YWdlOgogICAgIiIiRGV0ZWN0IHRoZSBsYW5ndWFnZSBvZiB0aGUg
-cHJvdmlkZWQgY29kZSBzbmlwcGV0LiIiIgogICAgaWYgZmlsZW5hbWU6CiAgICAgICAgaWYgZmls
-ZW5hbWUuZW5kc3dpdGgoIi5weSIpOgogICAgICAgICAgICByZXR1cm4gTGFuZ3VhZ2UuUFlUSE9O
-CiAgICAgICAgaWYgZmlsZW5hbWUuZW5kc3dpdGgoKCIuanMiLCAiLmpzeCIsICIudHMiLCAiLnRz
-eCIpKToKICAgICAgICAgICAgcmV0dXJuIExhbmd1YWdlLkpBVkFTQ1JJUFQKICAgICAgICBpZiBm
-aWxlbmFtZS5lbmRzd2l0aCgiLnNoIik6CiAgICAgICAgICAgIHJldHVybiBMYW5ndWFnZS5CQVNI
-CgogICAgIyBIZXVyaXN0aWNzIGZvciBzbmlwcGV0cyB3aXRob3V0IGZpbGVuYW1lcwogICAgIyBU
-aWdodGVuIEpTIGhldXJpc3RpY3MgdG8gcHJldmVudCBmYWxzZSBQeXRob24gbWF0Y2hlcwogICAg
-aWYgImNvbnN0ICIgaW4gY29kZSBvciAibGV0ICIgaW4gY29kZSBvciAiZnVuY3Rpb24gIiBpbiBj
-b2RlIG9yICIgPT4gIiBpbiBjb2RlOgogICAgICAgIHJldHVybiBMYW5ndWFnZS5KQVZBU0NSSVBU
-CiAgICBpZiAiaW1wb3J0ICIgaW4gY29kZSBhbmQgKCIgZnJvbSAiIGluIGNvZGUgb3IgInsiIGlu
-IGNvZGUpOgogICAgICAgIHJldHVybiBMYW5ndWFnZS5KQVZBU0NSSVBUCgogICAgaWYgImRlZiAi
-IGluIGNvZGUgb3IgKCJpbXBvcnQgIiBpbiBjb2RlIGFuZCAiZnJvbSAiIGluIGNvZGUpOgogICAg
-ICAgIHJldHVybiBMYW5ndWFnZS5QWVRIT04KCiAgICBpZiBjb2RlLnN0YXJ0c3dpdGgoIiMhIik6
-CiAgICAgICAgcmV0dXJuIExhbmd1YWdlLkJBU0gKCiAgICByZXR1cm4gTGFuZ3VhZ2UuVU5LTk9X
-TwoKZGVmIHBhcnNlX3B5dGhvbihjb2RlOiBzdHIpIC0+IFBhcnNlUmVzdWx0OgogICAgIiIiUGFy
-c2UgUHl0aG9uIGNvZGUgaW50byBhbiBBU1QgcmVwcmVzZW50YXRpb24uIiIiCiAgICB0cnk6CiAg
-ICAgICAgdHJlZSA9IGFzdC5wYXJzZShjb2RlKQogICAgICAgIGFzdF9kYXRhID0geyJ0eXBlIjog
-Ik1vZHVsZSIsICJib2R5X2NvdW50IjogbGVuKHRyZWUuYm9keSl9CiAgICAgICAgcmV0dXJuIFBh
-cnNlUmVzdWx0KGxhbmd1YWdlPUxhbmd1YWdlLlBZVEhPTiwgYXN0X2RhdGE9YXN0X2RhdGEpCiAg
-ICBleGNlcHQgU3ludGF4RXJyb3IgYXMgZToKICAgICAgICBlcnJvciA9IFBhcnNlRXJyb3IoCiAg
-ICAgICAgICAgIG1lc3NhZ2U9ZS5tc2csCiAgICAgICAgICAgIGxpbmU9ZS5saW5lbm8gb3IgMCwK
-ICAgICAgICAgICAgY29sdW1uPWUub2Zmc2V0IG9yIDAsCiAgICAgICAgICAgIHNvdXJjZT1lLnRl
-eHQgb3IgIiIKICAgICAgICApCiAgICAgICAgcmV0dXJuIFBhcnNlUmVzdWx0KGxhbmd1YWdlPUxh
-bmd1YWdlLlBZVEhPTiwgYXN0X2RhdGE9e30sIGVycm9ycz1bZXJyb3JdLCBzdWNjZXNzPUZhbHNl
-KQoKZGVmIHBhcnNlX2phdmFzY3JpcHQoY29kZTogc3RyKSAtPiBQYXNoUmVzdWx0OgogICAgIiIi
-UGFyc2UgSmF2YVNjcmlwdCBjb2RlIHVzaW5nIHB5anNwYXJzZXIuIiIiCiAgICBpZiBub3QganNf
-cGFyc2VyOgogICAgICAgIHJldHVybiBQYXJzZVJlc3VsdCgKICAgICAgICAgICAgbGFuZ3VhZ2U9
-TGFuZ3VhZ2UuSkFWQVNDUklQVCwKICAgICAgICAgICAgYXN0X2RhdGE9e30sCiAgICAgICAgICAg
-IGVycm9ycz1bUGFyc2VFcnJvcigicHlqc3BhcnNlciBsaWJyYXJ5IG5vdCBpbnN0YWxsZWQiLCAw
-LCAwLCAiIildLAogICAgICAgICAgICBzdWNjZXNzPUZhbHNlCiAgICAgICAgKQoKICAgIHRyeToK
-ICAgICAgICBhc3RfZGF0YSA9IGpzX3BhcnNlci5wYXJzZShjb2RlKQogICAgICAgIHJldHVybiBQ
-YXJzZVJlc3VsdChsYW5ndWFnZT1MYW5ndWFnZS5KQVZBU0NSSVBULCBhc3RfZGF0YT1hc3RfZGF0
-YSkKICAgIGV4Y2VwdCBFeGNlcHRpb24gYXMgZToKICAgICAgICByZXR1cm4gUGFyc2VSZXN1bHQo
-CiAgICAgICAgICAgIGxhbmd1YWdlPUxhbmd1YWdlLkpBVkFTQ1JJUFQsCiAgICAgICAgICAgIGFz
-dF9kYXRhPXt9LAogICAgICAgICAgICBlcnJvcnM9W1BhcnNlRXJyb3Ioc3RyKGUpLCAwLCAwLCAi
-IildLAogICAgICAgICAgICBzdWNjZXNzPUZhbHNlCiAgICAgICAgKQoKZGVmIHBhcnNlX2NvZGUo
-Y29kZTogc3RyLCBmaWxlbmFtZTogT3B0aW9uYWxbc3RyXSA9IE5vbmUpIC0+IFBhcnNlUmVzdWx0
-OgogICAgIiIiUHJpbWFyeSBBUEkgZm9yIHRoZSBDb2RlIFBhcnNpbmcgUGlwZWxpbmUuIiIiCiAg
-ICBsYW5nID0gZGV0ZWN0X2xhbmd1YWdlKGNvZGUsIGZpbGVuYW1lKQoKICAgIGlmIGxhbmcgPT0g
-TGFuZ3VhZ2UuUFlUSE9OOgogICAgICAgIHJldHVybiBwYXJzZV9weXRob24oY29kZSkKCiAgICBp
-ZiBsYW5nID09IExhbmd1YWdlLkpBVkFTQ1JJUFQ6CiAgICAgICAgcmV0dXJuIHBhcnNlX2phdmFz
-Y3JpcHQoY29kZSkKCiAgICByZXR1cm4gUGFyc2VSZXN1bHQoCiAgICAgICAgbGFuZ3VhZ2U9bGFu
-ZywKICAgICAgICBhc3RfZGF0YT17fSwKICAgICAgICBlcnJvcnM9W1BhcnNlRXJyb3IoZiJQYXJz
-ZXIgZm9yIHtsYW5nLnZhbHVlfSBub3QgeWV0IGltcGxlbWVudGVkIiwgMCwgMCwgIiIpXSwKICAg
-ICAgICBzdWNjZXNzPUZhbHNlCiAgICApCg==
+import ast
+import json
+from typing import Any
+
+from core.parser.types import Language, ParseError, ParseResult
+
+try:
+    from pyjsparser import PyJsParser
+except ImportError:  # pragma: no cover - optional dependency
+    PyJsParser = None
+
+js_parser = PyJsParser() if PyJsParser is not None else None
+
+
+def detect_language(code: str, filename: str | None = None) -> Language:
+    """Detect the language of the provided code snippet."""
+    if filename:
+        if filename.endswith(".py"):
+            return Language.PYTHON
+        if filename.endswith((".js", ".jsx", ".ts", ".tsx")):
+            return Language.JAVASCRIPT
+        if filename.endswith(".sh"):
+            return Language.BASH
+
+    # Heuristics for snippets without filenames. Check JavaScript first to avoid
+    # treating ES module imports as Python imports.
+    if (
+        "const " in code
+        or "let " in code
+        or "function " in code
+        or " => " in code
+    ):
+        return Language.JAVASCRIPT
+    if "import " in code and (" from " in code or "{" in code):
+        return Language.JAVASCRIPT
+
+    if "def " in code or ("import " in code and "from " in code):
+        return Language.PYTHON
+
+    if code.startswith("#!"):
+        return Language.BASH
+
+    return Language.UNKNOWN
+
+
+def parse_python(code: str) -> ParseResult:
+    """Parse Python code into an AST representation."""
+    try:
+        tree = ast.parse(code)
+        ast_data = {"type": "Module", "body_count": len(tree.body)}
+        return ParseResult(language=Language.PYTHON, ast_data=ast_data)
+    except SyntaxError as e:
+        error = ParseError(
+            message=e.msg,
+            line=e.lineno or 0,
+            column=e.offset or 0,
+            source=e.text or "",
+        )
+        return ParseResult(
+            language=Language.PYTHON,
+            ast_data={},
+            errors=[error],
+            success=False,
+        )
+
+
+def parse_javascript(code: str) -> ParseResult:
+    """Parse JavaScript code using pyjsparser when available."""
+    if not js_parser:
+        return ParseResult(
+            language=Language.JAVASCRIPT,
+            ast_data={},
+            errors=[ParseError("pyjsparser library not installed", 0, 0, "")],
+            success=False,
+        )
+
+    try:
+        ast_data: dict[str, Any] = js_parser.parse(code)
+        return ParseResult(language=Language.JAVASCRIPT, ast_data=ast_data)
+    except Exception as e:
+        return ParseResult(
+            language=Language.JAVASCRIPT,
+            ast_data={},
+            errors=[ParseError(str(e), 0, 0, "")],
+            success=False,
+        )
+
+
+def parse_code(code: str, filename: str | None = None) -> ParseResult:
+    """Primary API for the Code Parsing Pipeline."""
+    lang = detect_language(code, filename)
+
+    if lang == Language.PYTHON:
+        return parse_python(code)
+
+    if lang == Language.JAVASCRIPT:
+        return parse_javascript(code)
+
+    return ParseResult(
+        language=lang,
+        ast_data={},
+        errors=[ParseError(f"Parser for {lang.value} not yet implemented", 0, 0, "")],
+        success=False,
+    )
+
+
+def parse_code_to_json(code: str, filename: str | None = None) -> str:
+    """Serialize a parse result for CLI-style callers."""
+    result = parse_code(code, filename)
+    return json.dumps(
+        {
+            "language": result.language.value,
+            "ast_data": result.ast_data,
+            "errors": [error.__dict__ for error in result.errors],
+            "success": result.success,
+        }
+    )

--- a/core/parser/tests/test_parser.py
+++ b/core/parser/tests/test_parser.py
@@ -1,14 +1,23 @@
-aW1wb3J0IHB5dGVzdApmcm9tIGNvcmUucGFyc2VyLmVuZ2luZSBpbXBvcnQgcGFyc2VfY29kZSwg
-TGFuZ3VhZ2UKCmRlZiB0ZXN0X2xhbmd1YWdlX2RldGVjdGlvbigpOgogICAgYXNzZXJ0IHBhcnNl
-X2NvZGUoImRlZiBoZWxsbygpOiBwYXNzIikubGFuZ3VhZ2UgPT0gTGFuZ3VhZ2UuUFlUSE9OCiAg
-ICBhc3NlcnQgcGFyc2VfY29kZSgiY29uc3QgeCA9IDE7IikubGFuZ3VhZ2UgPT0gTGFuZ3VhZ2Uu
-SkFWQVNDUklQVAogICAgYXNzZXJ0IHBhcnNlX2NvZGUoIiMhL2Jpbi9iYXNoXG5lY2hvIDEiKS5s
-YW5ndWFnZSA9PSBMYW5ndWFnZS5CQVNICgpkZWYgdGVzdF9weXRob25fcGFyc2luZ19zdWNjZXNz
-KCk6CiAgICBjb2RlID0gImRlZiBhZGQoYSwgYik6IHJldHVybiBhICsgYiIKICAgIHJlc3VsdCA9
-IHBhcnNlX2NvZGUoY29kZSkKICAgIGFzc2VydCByZXN1bHQuc3VjY2VzcyBpcyBUcnVlCiAgICBh
-c3NlcnQgcmVzdWx0Lmxhbmd1YWdlID09IExhbmd1YWdlLlBZVEhPTgogICAgYXNzZXJ0IHJlc3Vs
-dC5hc3RfZGF0YVsidHlwZSJdID09ICJNb2R1bGUiCgpkZWYgdGVzdF9weXRob25fcGFyc2luZ19m
-YWlsdXJlKCk6CiAgICBjb2RlID0gImRlZiBpbnZhbGlkX3N5bnRheCgiCiAgICByZXN1bHQgPSBw
-YXJzZV9jb2RlKGNvZGUpCiAgICBhc3NlcnQgcmVzdWx0LnN1Y2Nlc3MgaXMgRmFsc2UKICAgIGFz
-c2VydCBsZW4ocmVzdWx0LmVycm9ycykgPiAwCiAgICBhc3NlcnQgcmVzdWx0LmVycm9yc1swXS5s
-aW5lID4gMAo=
+from core.parser.engine import Language, parse_code
+
+
+def test_language_detection() -> None:
+    assert parse_code("def hello(): pass").language == Language.PYTHON
+    assert parse_code("const x = 1;").language == Language.JAVASCRIPT
+    assert parse_code("#!/bin/bash\necho 1").language == Language.BASH
+
+
+def test_python_parsing_success() -> None:
+    code = "def add(a, b): return a + b"
+    result = parse_code(code)
+    assert result.success is True
+    assert result.language == Language.PYTHON
+    assert result.ast_data["type"] == "Module"
+
+
+def test_python_parsing_failure() -> None:
+    code = "def invalid_syntax("
+    result = parse_code(code)
+    assert result.success is False
+    assert len(result.errors) > 0
+    assert result.errors[0].line > 0

--- a/core/parser/types.py
+++ b/core/parser/types.py
@@ -1,9 +1,26 @@
-ZnJvbSBkYXRhY2xhc3NlcyBpbXBvcnQgZGF0YWNsYXNzLCBmaWVsZApmcm9tIGVudW0gaW1wb3J0
-IEVudW0KZnJvbSB0eXBpbmcgaW1wb3J0IEFueSwgRGljdCwgTGlzdCwgT3B0aW9uYWwKCmNsYXNz
-IExhbmd1YWdlKEVudW0pOgogICAgUFlUSE9OID0gInB5dGhvbiIKICAgIEpBVkFTQ1JJUFQgPSAi
-amF2YXNjcmlwdCIKICAgIEJBU0ggPSAiYmFzaCIKICAgIFVOS05PV04gPSAidW5rbm93biIKCkBk
-YXRhY2xhc3MKY2xhc3MgUGFyc2VFcnJvcjoKICAgIG1lc3NhZ2U6IHN0cgogICAgbGluZTogaW50
-CiAgICBjb2x1bW46IGludAogICAgc291cmNlOiBzdHIKCkBkYXRhY2xhc3MKY2xhc3MgUGFyc2VS
-ZXN1bHQ6CiAgICBsYW5ndWFnZTogTGFuZ3VhZ2UKICAgIGFzdF9kYXRhOiBEaWN0W3N0ciwgQW55
-XQogICAgZXJyb3JzOiBMaXN0W1BhcnNlRXJyb3JdID0gZmllbGQoZGVmYXVsdF9mYWN0b3J5PWxp
-c3QpCiAgICBzdWNjZXNzOiBib29sID0gVHJ1ZQo=
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class Language(Enum):
+    PYTHON = "python"
+    JAVASCRIPT = "javascript"
+    BASH = "bash"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ParseError:
+    message: str
+    line: int
+    column: int
+    source: str
+
+
+@dataclass
+class ParseResult:
+    language: Language
+    ast_data: dict[str, Any]
+    errors: list[ParseError] = field(default_factory=list)
+    success: bool = True

--- a/plugins/anthropic_code_suggester.py
+++ b/plugins/anthropic_code_suggester.py
@@ -7,6 +7,15 @@ try:
 except ImportError:  # pragma: no cover - optional dependency fallback
     class Anthropic:  # type: ignore[no-redef]
         def __init__(self, api_key: str) -> None:
+            """
+            Fallback constructor used when the external `anthropic` package is not available; it ignores `api_key` and always raises ImportError indicating the package is not installed.
+            
+            Parameters:
+                api_key (str): API key for Anthropic (unused).
+            
+            Raises:
+                ImportError: Always raised with the message "anthropic package is not installed".
+            """
             self.api_key = api_key
             msg = "anthropic package is not installed"
             raise ImportError(msg)
@@ -22,6 +31,11 @@ class AnthropicCodeSuggesterTool(AgentTool):
     """Tool for suggesting code improvements using Anthropic's Claude."""
 
     def __init__(self) -> None:
+        """
+        Initialize the AnthropicCodeSuggesterTool and configure its metadata and Anthropic client.
+        
+        Sets the tool's metadata (name, description, author, tags). Reads the `ANTHROPIC_API_KEY` environment variable and, if present, instantiates an Anthropic client assigned to `self.client`; if the key is missing, logs a warning and sets `self.client` to `None`.
+        """
         super().__init__()
         self.metadata = ToolMetadata(
             name="anthropic_code_suggester",
@@ -40,11 +54,39 @@ class AnthropicCodeSuggesterTool(AgentTool):
             self.client = Anthropic(api_key=api_key)
 
     def validate_inputs(self, inputs: dict[str, Any]) -> bool:
-        """Validate required inputs."""
+        """
+        Check that inputs contain a "code" key whose value is a string.
+        
+        Parameters:
+            inputs (dict[str, Any]): Input mapping expected to include a "code" entry.
+        
+        Returns:
+            bool: True if "code" is present in inputs and is a string, False otherwise.
+        """
         return "code" in inputs and isinstance(inputs["code"], str)
 
     def execute(self, inputs: dict[str, Any]) -> dict[str, Any]:
-        """Generate code suggestions using Anthropic."""
+        """
+        Generate code improvement suggestions for the provided source code using Anthropic Claude.
+        
+        Validates that `inputs["code"]` is a string; if validation fails, raises ValueError.
+        If the Anthropic client is not configured (API key missing) the function returns an error dictionary.
+        
+        Parameters:
+            inputs (dict[str, Any]): Input map containing a `"code"` key with source code to analyze.
+        
+        Returns:
+            dict[str, Any]: On success, a dict with keys:
+                - `suggestions` (str): The model's suggestions in text form (expected JSON string).
+                - `model` (str): The model identifier used.
+                - `status` (str): `"success"`.
+              On failure, a dict with keys:
+                - `error` (str): Error message.
+                - `status` (str): `"error"`.
+        
+        Raises:
+            ValueError: If `inputs` is missing a string `"code"` entry.
+        """
         if not self.validate_inputs(inputs):
             msg = "Input validation failed: 'code' must be a string"
             raise ValueError(msg)

--- a/plugins/anthropic_code_suggester.py
+++ b/plugins/anthropic_code_suggester.py
@@ -1,1 +1,99 @@
-aW1wb3J0IGxvZ2dpbmcKaW1wb3J0IG9zCmZyb20gdHlwaW5nIGltcG9ydCBBbnkKCmZyb20gYW50aHJvcGljIGltcG9ydCBBbnRocm9waWMKCmZyb20gdXRpbHMucGx1Z2lucy5iYXNlIGltcG9ydCBBZ2VudFRvb2wsIFRvb2xNZXRhZGF0YQoKIyBDb25maWd1cmUgbG9nZ2luZwpsb2dnaW5nLmJhc2ljQ29uZmlnKGxldmVsPWxvZ2dpbmcuSU5GTykKbG9nZ2VyID0gbG9nZ2luZy5nZXRMb2dnZXIoX19uYW1lX18pCgoKY2xhc3MgQW50aHJvcGljQ29kZVN1Z2dlc3RlclRvb2woQWdlbnRUb29sKToKICAgIKIiiIFRvb2wgZm9yIHN1Z2dlc3RpbmcgY29kZSBpbXByb3ZlbWVudHMgdXNpbmcgQW50aHJvcGljJ3MgQ2xhdWRlCgogICAgQSB0b29sIGZvciBnZW5lcmF0aW5nIGNvZGUgaW1wcm92ZW1lbnQgc3VnZ2VzdGlvbnMgdXNpbmcgQW50aHJvcGljJ3MKICAgIENsYXVkZSBBSSBtb2RlbC4gVGhpcyBjbGFzcyBleHRlbmRzIEFnZW50VG9vbCB0byBwcm92aWRlIEFJLXBvd2VyZWQKICAgIGNvZGUgYW5hbHlzaXMgYW5kIHN1Z2dlc3Rpb25zLiBJdCBsZXZlcmFnZXMgQW50aHJvcGljJ3MgQ2xhdWRlIG1vZGVsCiAgICB0byBldmFsdWF0ZSBwcm92aWRlZCBjb2RlIHNuaXBwZXRzIGFuZCBvZmZlciByZWNvbW1lbmRhdGlvbnMgb24KICAgIHN0cnVjdHVyZSwgb3B0aW1pemF0aW9uLCBiZXN0IHByYWN0aWNlcywgYW5kIGVycm9yIGhhbmRsaW5nLgoKICAgIEF0dHJpYnV0ZXM6CiAgICAgICAgbWV0YWRhdGEgKFRvb2xNZXRhZGF0YSk6IE1ldGFkYXRhIGRlc2NyaWJpbmcgdGhlIHRvb2wsIGluY2x1ZGluZwogICAgICAgICAgICBuYW1lLCBkZXNjcmlwdGlvbiwgdmVyc2lvbiwgYXV0aG9yLCBhbmQgdGFncy4KICAgICAgICBjbGllbnQgKEFudGhyb3BpYyk6IFRoZSBBbnRocm9waWMgY2xpZW50IGluc3RhbmNlIHVzZWQgZm9yIEFQSQogICAgICAgICAgICBpbnRlcmFjdGlvbnMuCgogICAgTWV0aG9kczoKICAgICAgICB2YWxpZGF0ZV9pbnB1dHMoaW5wdXRzOiBEaWN0W3N0ciwgQW55XSkgLT4gYm9vbDoKICAgICAgICAgICAgVmFsaWRhdGVzIHRoZSBpbnB1dCBkaWN0aW9uYXJ5IHRvIGVuc3VyZSBpdCBjb250YWlucyBhIHZhbGlkCiAgICAgICAgICAgICdjb2RlJyBrZXkgd2l0aCBhIHN0cmluZyB2YWx1ZS4KICAgICAgICBleGVjdXRlKGlucHV0czogRGljdFtzdHIsIEFueV0pIC0+IERpY3Rbc3RyLCBBbnldOgogICAgICAgICAgICBFeGVjdXRlcyB0aGUgY29kZSBzdWdnZXN0aW9uIHByb2Nlc3MgYnkgc2VuZGluZyB0aGUgY29kZSB0bwogICAgICAgICAgICBDbGF1ZGUgZm9yIGFuYWx5c2lzIGFuZCByZXR1cm5pbmcgdGhlIHN1Z2dlc3Rpb25zIGluIGEKICAgICAgICAgICAgc3RydWN0dXJlZCByZXNwb25zZS4KICAgIE5vdGU6CiAgICAgICAgUmVxdWlyZXMgYW4gQU5USFJPUElDX0FQSV9LRVkgZW52aXJvbm1lbnQgdmFyaWFibGUgdG8gYmUgc2V0IGZvciBhdXRoZW50aWNhdGlvbi4KICAgICAgICBUaGUgdG9vbCB1c2VzIHRoZSAnY2xhdWRlLTMtNS1zb25uZXQtMjAyNDEwMjInIG1vZGVsIGZvciBnZW5lcmF0aW5nIHN1Z2dlc3Rpb25zLgogICAgRXhhbXBsZToKICAgICAgICA+Pj4gdG9vbCA9IEFudGhyb3BpY0NvZGVTdWdnZXN0ZXJUb29sKCkKICAgICAgICA+Pj4gcmVzdWx0ID0gdG9vbC5leGVjdXRlKHsiY29kZSI6ICJkZWYgaGVsbG8oKTogcHJpbnQoJ0hlbGxvJykifSkKICAgICAgICA+Pj4gcHJpbnQocmVzdWx0WyJzdWdnZXN0aW9ucyJdKQogICAgIiIiCgogICAgZGVmIF9faW5pdF9fKHNlbGYpIC0+IE5vbmU6CiAgICAgICAgc3VwZXIoKS5fX2luaXRfXygpCiAgICAgICAgc2VsZi5tZXRhZGF0YSA9IFRvb2xNZXRhZGF0YSgKICAgICAgICAgICAgbmFtZT0iYW50aHJvcGljX2NvZGVfc3VnZ2VzdGVyIiwKICAgICAgICAgICAgZGVzY3JpcHRpb249IlN1Z2dlc3RzIGNvZGUgaW1wcm92ZW1lbnRzIHVzaW5nIEFudGhyb3BpYydzIENsYXVkZSBtb2RlbCIsCiAgICAgICAgICAgIHZlcnNpb249IjAuMS4wIiwKICAgICAgICAgICAgYXV0aG9yPSJDb2RlVHVuZVN0dWRpbyIsCiAgICAgICAgICAgIHRhZ3M9WyJjb2RlLXN1Z2dlc3Rpb25zIiwgImFpIiwgImFudGhyb3BpYyJdLAogICAgICAgICkKICAgICAgICAjIEluaXRpYWxpemUgQW50aHJvcGljIGNsaWVudCB3aXRoIHZhbGlkYXRpb24KICAgICAgICBhcGlfa2V5ID0gb3MuZW52aXJvbi5nZXQoIkFOVEhST1BJQ19BUElfS0VZIikKICAgICAgICBpZiBub3QgaXBpX2tleToKICAgICAgICAgICAgbG9nZ2VyLndhcm5pbmcoCiAgICAgICAgICAgICAgICAiQU5USFJPUElDX0FQSV9LRVkgbm90IHNldC4gQW50aHJvcGljIGNvZGUgc3VnZ2VzdGlvbnMgIgogICAgICAgICAgICAgICAgIndpbGwgbm90IGJlIGF2YWlsYWJsZS4iCiAgICAgICAgICAgICkKICAgICAgICAgICAgc2VsZi5jbGllbnQgPSBOb25lCiAgICAgICAgZWxzZToKICAgICAgICAgICAgc2VsZi5jbGllbnQgPSBBbnRocm9waWMoYXBpX2tleT1hcGlfa2V5KQoKICAgIGRlZiB2YWxpZGF0ZV9pbnB1dHMoc2VsZiwgaW5wdXRzOiBkaWN0W3N0ciwgQW55XSkgLT4gYm9vbDoKICAgICAgICAiIiIKICAgICAgICBWYWxpZGF0ZSByZXF1aXJlZCBpbnB1dHMuIFJldHVybnMgVHJ1ZSBpZiB2YWxpZCwgb3RoZXJ3aXNlIHJhaXNlcwogICAgICAgIFZhbHVlRXJyb3Igd2l0aCBkZXRhaWxlZCBlcnJvciBpbmZvcm1hdGlvbi4KICAgICAgICAiIiIKICAgICAgICBpZiAiY29kZSIgbm90IGluIGlucHV0czoKICAgICAgICAgICAgcmFpc2UgVmFsdWVFcnJvcihJbnB1dCB2YWxpZGF0aW9uIGZhaWxlZDogTWlzc2luZyBrZXkgJ2NvZGUnIikKICAgICAgICAgaWYgbm90IGlzaW5zdGFuY2UoaW5wdXRzWyJjb2RlIl0sIHN0cik6CiAgICAgICAgICAgIHJhaXNlIFZhbHVlRXJyb3IoIklucHV0IHZhbGlkYXRpb24gZmFpbGVkOiAnY29kZScgbXVzdCBiZSBhIHN0cmluZyIpCiAgICAgICAgcmV0dXJuIFRydWUKCiAgICBkZWYgZXhlY3V0ZShzZWxmLCBpbnB1dHM6IGRpY3Rbc3RyLCBBbnldKSAtPiBkaWN0W3N0ciwgQW55XToKICAgICAgICAiIiIKICAgICAgICBHZW5lcmF0ZSBjb2RlIHN1Z2dlc3Rpb25zIHVzaW5nIEFudGhyb3BpYwoKICAgICAgICBBcmdzOgogICAgICAgICAgICBpbnB1dHM6IERpY3Rpb25hcnkgY29udGFpbmluZzoKICAgICAgICAgICAgICAgIC0gY29kZTogU3RyaW5nIGNvbnRhaW5pbmcgY29kZSB0byBhbmFseXplCgogICAgICAgIFJldHVybnM6CiAgICAgICAgICAgIERpY3Rpb25hcnkgY29udGFpbmluZyBzdWdnZXN0ZWQgaW1wcm92ZW1lbnRzCiAgICAgICAgIiIiCiAgICAgICAgdHJ5OgogICAgICAgICAgICBzZWxmLnZhbGlkYXRlX2lucHV0cyhpbnB1dHMpCiAgICAgICAgZXhjZXB0IFZhbHVlRXJyb3IgYXMgZToKICAgIC2cmV0dXJuIHsiZXJyb3IiOiBzdHIoZSksICJzdGF0dXMiOiAiZXJyb3IifQoKICAgICAgICBpZiBub3Qgc2VsZi5jbGllbnQ6CiAgICAgICAgICAgIHJldHVybiB7CiAgICAgICAgICAgICAgICAiZXJyb3IiOiAoCiAgICAgICAgICAgICAgICAgICAgIkFOVEhST1BJQ19BUElfS0VZIG5vdCBjb25maWd1cmVkLiBQbGVhc2Ugc2V0IHRoZSAiCiAgICAgICAgICAgICAgICAgICAgIkFQSSBrZXkgdG8gdXNlIHRoaXMgdG9vbC4iCiAgICAgICAgICAgICAgICApLAogICAgICAgICAgICAgICAgInN0YXR1cyI6ICJlcnJvciIsCiAgICAgICAgICAgIH0KCiAgICAgICAgdHJ5OgogICAgICAgICAgICAjIFRoZSBuZXdlc3QgQW50aHJvcGljIG1vZGVsIGlzICJjbGF1ZGUtMy01LXNvbm5ldC0yMDI0MTAyMiIKICAgICAgICAgICAgIyBSZWxlYXNlZCBPY3RvYmVyIDIyLCAyMDI0CiAgICAgICAgICAgIG1lc3NhZ2UgPSBzZWxmLmNsaWVudC5tZXNzYWdlcy5jcmVhdGUoCiAgICAgICAgICAgICAgICBtb2RlbD0iY2xhdWRlLTMtNS1zb25uZXQtMjAyNDEwMjIiLAogICAgICAgICAgICAgICAgbWF4X3Rva2Vucz00MDk2LAogICAgICAgICAgICAgICAgbWVzc2FnZXM9WwogICAgICAgICAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICAgICAgICAgInJvbGUiOiAidXNlciIsCiAgICAgICAgICAgICAgICAgICAgICAgICJjb250ZW50IjogKAogICAgICAgICAgICAgICAgICAgICAgICAgICAgIkFuYWx5emUgdGhpcyBjb2RlIGFuZCBzdWdnZXN0IGltcHJvdmVtZW50cyAiCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAiaW4gSlNPTiBmb3JtYXQuXG4iCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAiSW5jbHVkZSBzcGVjaWZpYyByZWNvbW1lbmRhdGlvbnMgZm9yOlxuIgogICAgICAgICAgICAgICAgICAgICAgICAgICAgIjEuIENvZGUgc3RydWN0dXJlXG4iCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAiMi4gT3B0aW1pemF0aW9uIG9wcG9ydHVuaXRpZXNcbiIKICAgICAgICAgICAgICAgICAgICAgICAgICAgICIzLiBCZXN0IHByYWN0aWNlc1xuIgogICAgICAgICAgICAgICAgICAgICAgICAgICAgIjQuIEVycm9yIGhhbmRsaW5nXG5cbiIKICAgICAgICAgIC2ICAgICAgIkNvZGUgdG8gYW5hbHl6ZTpcbiIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGZ7aW5wdXRzWydjb2RlJ119IgogICAgICAgICAgICAgICAgICAgICAgICAgICAgKSwKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBdLAogICAgICAgICAgICApCgogICAgICAgICAgICAjIFZhbGlkYXRlIHJlc3BvbnNlIHN0cnVjdHVyZSBiZWZvcmUgYWNjZXNzaW5nCiAgICAgICAgICAgIGlmIG5vdCBtZXNzYWdlLmNvbnRlbnQgb3IgbGVuKG1lc3NhZ2UuY29udGVudCkgPT0gMDoKICAgICAgICAgICAgICAgIGxvZ2dlci5lcnJvcigiQW50aHJvcGljIEFQSSByZXR1cm5lZCBlbXB0eSBjb250ZW50IikKICAgICAgICAgICAgICAgIHJldHVybiB7ImVycm9yIjogIkFQSSByZXR1cm5lZCBlbXB0eSByZXNwb25zZSIsICJzdGF0dXMiOiAiZXJyb3IifQoKICAgICAgICAgICAgaWYgbm90IGhhc2F0dHIobWVzc2FnZS5jb250ZW50WzBdLCAidGV4dCIpOgogICAgICAgICAgICAgICAgbG9nZ2VyLmVycm9yKCJBbnRocm9waWMgQVBJIHJlc3BvbnNlIG1pc3NpbmcgdGV4dCBhdHRyaWJ1dGUiKQogICAgICAgICAgICAgICAgcmV0dXJuIHsiZXJyb3IiOiAiIkludmFsaWQgQVBJIHJlc3BvbnNlIGZvcm1hdCIsICJzdGF0dXMiOiAiZXJyb3IifQoKICAgICAgICAgICAgcmV0dXJuIHsKICAgICAgICAgICAgICAgICJzdWdnZXN0aW9ucyI6IG1lc3NhZ2UuY29udGVudFswXS50ZXh0LAogICAgICAgICAgICAgICAgIm1vZGVsIjogImNsYXVkZS0zLTUtc29ubmV0LTIwMjQxMDIyIiwKICAgICAgICAgICAgICAgICJzdGF0dXMiOiAic3VjY2VzcyIsCiAgICAgICAgICAgIH0KICAgICAgICBleGNlcHQgRXhjZXB0aW9uIGFzIGU6CiAgICAgICAgICAgIGxvZ2dlci5leGNlcHRpb24oZiJBbnRocm9waWMgY29kZSBzdWdnZXN0aW9uIGZhaWxlZDoge2Uhc30iKQogICAgICAgICAgICByZXR1cm4geyJlcnJvciI6IHN0cihlKSwgInN0YXR1cyI6ICJlcnJvciJ9Cg==
+import logging
+import os
+from typing import Any
+
+try:
+    from anthropic import Anthropic
+except ImportError:  # pragma: no cover - optional dependency fallback
+    class Anthropic:  # type: ignore[no-redef]
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+            msg = "anthropic package is not installed"
+            raise ImportError(msg)
+
+from utils.plugins.base import AgentTool, ToolMetadata
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class AnthropicCodeSuggesterTool(AgentTool):
+    """Tool for suggesting code improvements using Anthropic's Claude."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.metadata = ToolMetadata(
+            name="anthropic_code_suggester",
+            description="Suggests code improvements using Anthropic's Claude model",
+            author="CodeTuneStudio",
+            tags=["code-suggestions", "ai", "anthropic"],
+        )
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            logger.warning(
+                "ANTHROPIC_API_KEY not set. Anthropic code suggestions "
+                "will not be available."
+            )
+            self.client = None
+        else:
+            self.client = Anthropic(api_key=api_key)
+
+    def validate_inputs(self, inputs: dict[str, Any]) -> bool:
+        """Validate required inputs."""
+        return "code" in inputs and isinstance(inputs["code"], str)
+
+    def execute(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Generate code suggestions using Anthropic."""
+        if not self.validate_inputs(inputs):
+            msg = "Input validation failed: 'code' must be a string"
+            raise ValueError(msg)
+
+        if not self.client:
+            return {
+                "error": (
+                    "ANTHROPIC_API_KEY not configured. Please set the "
+                    "API key to use this tool."
+                ),
+                "status": "error",
+            }
+
+        try:
+            model = "claude-3-5-sonnet-20241022"
+            message = self.client.messages.create(
+                model=model,
+                max_tokens=4096,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": (
+                            "Analyze this code and suggest improvements "
+                            "in JSON format.\n"
+                            "Include specific recommendations for:\n"
+                            "1. Code structure\n"
+                            "2. Optimization opportunities\n"
+                            "3. Best practices\n"
+                            "4. Error handling\n\n"
+                            "Code to analyze:\n"
+                            f"{inputs['code']}"
+                        ),
+                    }
+                ],
+            )
+
+            if not message.content:
+                logger.error("Anthropic API returned empty content")
+                return {"error": "API returned empty response", "status": "error"}
+
+            if not hasattr(message.content[0], "text"):
+                logger.error("Anthropic API response missing text attribute")
+                return {"error": "Invalid API response format", "status": "error"}
+
+            return {
+                "suggestions": message.content[0].text,
+                "model": model,
+                "status": "success",
+            }
+        except Exception as e:
+            logger.exception("Anthropic code suggestion failed")
+            return {"error": str(e), "status": "error"}

--- a/plugins/openai_code_analyzer.py
+++ b/plugins/openai_code_analyzer.py
@@ -9,6 +9,12 @@ try:
 except ImportError:  # pragma: no cover - optional dependency fallback
     class OpenAI:  # type: ignore[no-redef]
         def __init__(self, api_key: str) -> None:
+            """
+            Initialize a minimal fallback OpenAI client.
+            
+            Parameters:
+                api_key (str): API key used for authentication; stored for compatibility with the real client.
+            """
             self.api_key = api_key
             self.chat = None
 
@@ -79,14 +85,19 @@ class OpenAICodeAnalyzerTool(AgentTool):
 
     def execute(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """
-        Analyze code using OpenAI
-
-        Args:
-            inputs: Dictionary containing:
-                - code: String containing code to analyze
-
+        Analyze provided source code with the OpenAI chat completion API and return a structured analysis.
+        
+        Parameters:
+            inputs (dict[str, Any]): Mapping that must include a "code" key with the source code string to analyze.
+        
         Returns:
-            Dictionary containing analysis results
+            dict[str, Any]: On success, contains:
+                - "analysis": JSON-serializable analysis produced by the model (may be a dict or string),
+                - "model": the model identifier used ("gpt-4o"),
+                - "status": "success".
+            On error, contains:
+                - "error": error message string,
+                - "status": "error".
         """
         if not self.validate_inputs(inputs):
             return {

--- a/plugins/openai_code_analyzer.py
+++ b/plugins/openai_code_analyzer.py
@@ -1,8 +1,20 @@
 import logging
 import os
+import sys
+import types
 from typing import Any
 
-from openai import OpenAI
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - optional dependency fallback
+    class OpenAI:  # type: ignore[no-redef]
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+            self.chat = None
+
+    openai_module = types.ModuleType("openai")
+    openai_module.OpenAI = OpenAI
+    sys.modules.setdefault("openai", openai_module)
 
 from utils.plugins.base import AgentTool, ToolMetadata
 
@@ -121,10 +133,10 @@ class OpenAICodeAnalyzerTool(AgentTool):
                     "status": "success",
                 }
             logger.error("OpenAI API response missing expected content.")
-            return {
+            return {  # noqa: TRY300
                 "error": "OpenAI API response missing expected content.",
                 "status": "error",
             }
         except Exception as e:
-            logger.exception(f"OpenAI code analysis failed: {e!s}")
+            logger.exception("OpenAI code analysis failed")
             return {"error": str(e), "status": "error"}

--- a/scripts/validate_workflows.py
+++ b/scripts/validate_workflows.py
@@ -1,4 +1,292 @@
-IyEvdXNyL2Jpbi9lbnYgcHl0aG9uMwoiIiIKV29ya2Zsb3cgVmFsaWRhdGlvbiBTY3JpcHQKClRoaXMgc2NyaXB0IHZhbGlkYXRlcyBHaXRIdWIgd29ya2Zsb3cgZmlsZXMgZm9yIHN5bnRheCwgc2VjdXJpdHksIGFuZCBiZXN0IHByYWN0aWNlcy4KQ2FuIGJlIHJ1biBsb2NhbGx5IG9yIGluIENJIHRvIGVuc3VyZSB3b3JrZmxvd3MgYXJlIHByb3Blcmx5IGNvbmZpZ3VyZWQuCgpVc2FnZToKICAgIHB5dGhvbiBzY3JpcHRzL3ZhbGlkYXRlX3dvcmtmbG93cy5weQogICAgcHl0aG9uIHNjcmlwdHMvdmFsaWRhdGVfd29ya2Zsb3dzLnB5IC0td29ya2Zsb3cgY2kueW1sCiAgICBweXRob24gc2NyaXB0cy92YWxpZGF0ZV93b3JrZmxvd3MucHkgLS1zZWN1cml0eS1vbmx5CiIiIgoKaW1wb3J0IGFyZ3BhcnNlCmltcG9ydCBzeXMKZnJvbSBwYXRobGliIGltcG9ydCBQYXRoCmZyb20gdHlwaW5nIGltcG9ydCBMaXN0LCBEaWN0LCBBbnksIFR1cGxlCmltcG9ydCB5YW1sCmltcG9ydCByZQoKCmNsYXNzIFdvcmtmbG93VmFsaWRhdG9yOgogICAgIiIiVmFsaWRhdGVzIEdpdEh1YiB3b3JrZmxvdyBmaWxlcyIiIgoKICAgIGRlZiBfX2luaXRfXyhzZWxmLCByZXBvX3Jvb3Q6IFBhdGgpOgogICAgICAgIHNlbGYucmVwb19yb290ID0gcmVwb19yb290CiAgICAgICAgc2VsZi53b3JrZmxvd3NfZGlyID0gcmVwb19yb290IC8gIi5naXRodWIiIC8gIndvcmtmbG93cyIKICAgICAgICBzZWxmLmVycm9yczogTGlzdFtzdHJdID0gW10KICAgICAgICBzZWxmLndhcm5pbmdzOiBMaXN0W3N0cl0gPSBbXQogICAgICAgIHNlbGYuaW5mbzogTGlzdFtzdHJdID0gW10KCiAgICBkZWYgdmFsaWRhdGVfYWxsKHNlbGYsIHdvcmtmbG93X25hbWU6IHN0ciA9IE5vbmUpIC0+IGJvb2w6CiAgICAgICAgIiIiCiAgICAgICAgVmFsaWRhdGUgYWxsIHdvcmtmbG93cyBvciBhIHNwZWNpZmljIHdvcmtmbG93CgogICAgICAgIEFyZ3M6CiAgICAgICAgICAgIHdvcmtmbG93X25hbWU6IE9wdGlvbmFsIHNwZWNpZmljIHdvcmtmbG93IHRvIHZhbGlkYXRlCgogICAgICAgIFJldHVybnM6CiAgICAgICAgICAgIFRydWUgaWYgdmFsaWRhdGlvbiBwYXNzZXMsIEZhbHNlIG90aGVyd2lzZQogICAgICAgICIiIgogICAgICAgIHByaW50KCLwn5SMIEdpdEh1YiBXb3JrZmxvdyBWYWxpZGF0b3IiKQogICAgICAgIHByaW50KCI9IiAqIDYwKQoKICAgICAgICBpZiB3b3JrZmxvd19uYW1lOgogICAgICAgICAgICB3b3JrZmxvd19maWxlID0gc2VsZi53b3JrZmxvd3NfZGlyIC8gd29ya2Zsb3dfbmFtZQogICAgICAgICAgICBpZiBub3Qgd29ya2Zsb3dfZmlsZS5leGlzdHMoKToKICAgICAgICAgICAgICAgIHNlbGYuZXJyb3JzLmFwcGVuZChmIldvcmtmbG93IGZpbGUgbm90IGZvdW5kOiB7d29ya2Zsb3dfbmFtZX0iKQogICAgICAgICAgICAgICAgcmV0dXJuIEZhbHNlCiAgICAgICAgICAgIHdvcmtmbG93cyA9IFt3b3JrZmxvd19maWxlXQogICAgICAgIGVsc2U6CiAgICAgICAgICAgIHdvcmtmbG93cyA9IHNlbGYuX2dldF93b3JrZmxvd19maWxlcygpCgogICAgICAgIGlmIG5vdCB3b3JrZmxvd3M6CiAgICAgICAgICAgIHNlbGYuZXJyb3JzLmFwcGVuZCgiTm8gd29ya2Zsb3cgZmlsZXMgZm91bmQiKQogICAgICAgICAgICByZXR1cm4gRmFsc2UKCiAgICAgICAgcHJpbnQoZiLwn5O7IEZvdW5kIHtsZW4od29ya2Zsb3dzKX0gd29ya2Zsb3cgZmlsZShzKSB0byB2YWxpZGF0ZVxuIikKCiAgICAgICAgZm9yIHdvcmtmbG93IGluIHdvcmtmbG93czoKICAgICAgICAgICAgc2VsZi5fdmFsaWRhdGVfd29ya2Zsb3cod29ya2Zsb3cpCgogICAgICAgIHNlbGYuX3ByaW50X3Jlc3VsdHMoKQogICAgICAgIHJldHVybiBsZW4oc2VsZi5lcnJvcnMpID09IDAKCiAgICBkZWYgX2dldF93b3JrZmxvd19maWxlcyhzZWxmKSAtPiBMaXN0W1BhdGhdOgogICAgICAgICIiIkdldCBhbGwgd29ya2Zsb3cgZmlsZXMiIiIKICAgICAgICB3b3JrZmxvd3MgPSBbXQogICAgICAgIGZvciBwYXR0ZXJuIGluIFsiKi55bWwiLCAiKi55YW1sIl06CiAgICAgICAgICAgIHdvcmtmbG93cy5leHRlbmQoc2VsZi53b3JrZmxvd3NfZGlyLmdsb2IocGF0dGVybikpCiAgICAgICAgICAgIHdvcmtmbG93cy5leHRlbmQoc2VsZi53b3JrZmxvd3NfZGlyLmdsb2IoZiIqKi97cGF0dGVybn0iKSkKICAgICAgICByZXR1cm4gc29ydGVkKHNldCh3b3JrZmxvd3MpKQoKICAgIGRlZiBfdmFsaWRhdGVfd29ya2Zsb3coc2VsZiwgd29ya2Zsb3dfcGF0aDogUGF0aCk6CiAgICAgICAgIiIiVmFsaWRhdGUgYSBzaW5nbGUgd29ya2Zsb3cgZmlsZSIiIgogICAgICAgIHByaW50KGYi8J+ThCBWYWxpZGF0aW5nOiB7d29ya2Zsb3dfcGF0aC5yZWxhdGl2ZV90byhzZWxmLnJlcG9fcm9vdCl9IikKCiAgICAgICAgIyBDaGVjayBZQU1MIHN5bnRheAogICAgICAgIHRyeToKICAgICAgICAgICAgd2l0aCBvcGVuKHdvcmtmbG93X3BhdGgsICJyIikgYXMgZjoKICAgICAgICAgICAgICAgIHJhd19jb250ZW50ID0gZi5yZWFkKCkKICAgICAgICAgICAgICAgIGYuc2VlaygwKQogICAgICAgICAgICAgICAgY29udGVudCA9IHlhbWwuc2FmZV9sb2FkKGYpCiAgICAgICAgZXhjZXB0IHlhbWwuWUFNTEVycm9yIGFzIGU6CiAgICAgICAgICAgIHNlbGYuZXJyb3JzLmFwcGVuZChmInt3b3JrZmxvd19wYXRoLm5hbWV9OiBJbnZhbGlkIFlBTUwgLSB7ZX0iKQogICAgICAgICAgICByZXR1cm4KICAgICAgICBleGNlcHQgRXhjZXB0aW9uIGFzIGU6CiAgICAgICAgICAgIHNlbGYuZXJyb3JzLmFwcGVuZChmInt3b3JrZmxvd19wYXRoLm5hbWV9OiBFcnJvciByZWFkaW5nIGZpbGUgLSB7ZX0iKQogICAgICAgICAgICByZXR1cm4KCiAgICAgICAgaWYgY29udGVudCBpcyBOb25lOgogICAgICAgICAgICBzZWxmLndhcm5pbmdzLmFwcGVuZChmInt3b3JrZmxvd19wYXRoLm5hbWV9OiBFbXB0eSB3b3JrZmxvdyBmaWxlIikKICAgICAgICAgICAgcmV0dXJuCgogICAgICAgICMgQ2hlY2sgaWYgdGhpcyBpcyBhIG1ldGFkYXRhIGZpbGUgKG5vdCBhIHdvcmtmbG93KQogICAgICAgIGlmIHNlbGYuX2lzX21ldGFkYXRhX2ZpbGUod29ya2Zsb3dfcGF0aC5uYW1lLCBjb250ZW50KToKICAgICAgICAgICAgcHJpbnQoZiIgIOKEue++jyAgTWV0YWRhdGEgZmlsZSAobm90IGEgd29ya2Zsb3cpIC0gc2tpcHBpbmcgd29ya2Zsb3cgdmFsaWRhdGlvblxuIikKICAgICAgICAgICAgcmV0dXJuCgogICAgICAgICMgVmFsaWRhdGUgc3RydWN0dXJlCiAgICAgICAgc2VsZi5fdmFsaWRhdGVfc3RydWN0dXJlKHdvcmtmbG93X3BhdGgubmFtZSwgY29udGVudCkKCiAgICAgICAgIyBWYWxpZGF0ZSBzZWN1cml0eQogICAgICAgIHNlbGYuX3ZhbGlkYXRlX3NlY3VyaXR5KHdvcmtmbG93X3BhdGgubmFtZSwgcmF3X2NvbnRlbnQsIGNvbnRlbnQpCgogICAgICAgICMgVmFsaWRhdGUgYmVzdCBwcmFjdGljZXMKICAgICAgICBzZWxmLl92YWxpZGF0ZV9iZXN0X3ByYWN0aWNlcyh3b3JrZmxvd19wYXRoLm5hbWUsIGNvbnRlbnQpCgogICAgICAgIHByaW50KGYiICDinpMgVmFsaWRhdGlvbiBjb21wbGV0ZVxuIikKCiAgICBkZWYgX2lzX21ldGFkYXRhX2ZpbGUoc2VsZiwgZmlsZW5hbWU6IHN0ciwgY29udGVudDogRGljdFtzdHIsIEFueV0pIC0+IGJvb2w6CiAgICAgICAgIiIiQ2hlY2sgaWYgZmlsZSBpcyBtZXRhZGF0YSByYXRoZXIgdGhhbiBhIHdvcmtmbG93IiIiCiAgICAgICAgIyBDaGVjayBmb3IgSEYgU3BhY2UgbWV0YWRhdGEgaW5kaWNhdG9ycwogICAgICAgIGlmICJzZGsiIGluIGNvbnRlbnQgb3IgImVtb2ppIiBpbiBjb250ZW50IG9yICJjb2xvckZyb20iIGluIGNvbnRlbnQ6CiAgICAgICAgICAgIHJldHVybiBUcnVlCiAgICAgICAgCiAgICAgICAgIyBmaWxlcyB0aGF0IGNvbnRhaW4gJ3RpdGxlJyBidXQgbm8gJ2pvYnMnIGFyZSBsaWtlbHkgbWV0YWRhdGEKICAgICAgICBpZiAidGl0bGUiIGluIGNvbnRlbnQgYW5kICJqb2JzIiBub3QgaW4gY29udGVudCBhbmQgIm9uIiBub3QgaW4gY29udGVudDsKICAgICAgICAgICAgcmV0dXJuIFRydWUKICAgICAgICAgICAgCiAgICAgICAgcmV0dXJuIEZhbHNlCgogICAgZGVmIF92YWxpZGF0ZV9zdHJ1Y3R1cmUoc2VsZiwgZmlsZW5hbWU6IHN0ciwgY29udGVudDogRGljdFtzdHIsIEFueV0pOgogICAgICAgICIiIlZhbGlkYXRlIHdvcmtmbG93IHN0cnVjdHVyZSIiIgogICAgICAgICMgQ2hlY2sgcmVxdWlyZWQgZmllbGRzCiAgICAgICAgaWYgIm5hbWUiIG5vdCBpbiBjb250ZW50OgogICAgICAgICAgICBzZWxmLndhcm5pbmdzLmFwcGVuZChmIntmaWxlbmFtZX06IE1pc3NpbmcgJ25hbWUnIGZpZWxkIikKCiAgICAgICAgIyBDaGVjayBmb3IgdHJpZ2dlciAob246IG9yIFRydWUgZm9yIFlBTUwgYm9vbGVhbikKICAgICAgICBoYXNfdHJpZ2dlciA9ICJvbiIgaW4gY29udGVudCBvciBUcnVlIGluIGNvbnRlbnQKICAgICAgICBpZiBub3QgaGFzX3RyaWdnZXI6CiAgICAgICAgICAgIHNlbGYuZXJyb3JzLmFwcGVuZChmIntmaWxlbmFtZX06IE1pc3NpbmcgdHJpZ2dlciAoJ29uJyBmaWVsZCkiKQoKICAgICAgICBpZiAiam9icyIgbm90IGluIGNvbnRlbnQ6CiAgICAgICAgICAgIHNlbGYuZXJyb3JzLmFwcGVuZChmIntmaWxlbmFtZX06IE1pc3NpbmcgJ2pvYnMnIGRlZmluaXRpb24iKQogICAgICAgICAgICByZXR1cm4KCiAgICAgICAgIyBWYWxpZGF0ZSBqb2JzCiAgICAgICAgam9icyA9IGNvbnRlbnQuZ2V0KCJqb2JzIiwge30pCiAgICAgICAgaWYgbm90IGlzaW5zdGFuY2Uoam9icywgZGljdCk6CiAgICAgICAgICAgIHNlbGYuZXJyb3JzLmFwcGVuZChmIntmaWxlbmFtZX06ICdqb2JzJyBtdXN0IGJlIGEgZGljdGlvbmFyeSIpCiAgICAgICAgICAgIHJldHVybgoKICAgICAgICBpZiBub3Qgam9iczoKICAgICAgICAgICAgc2VsZi5lcnJvcnMuYXBwZW5kKGYie2ZpbGVuYW1lfTogTm8gam9icyBkZWZpbmVkIikKICAgICAgICAgICAgcmV0dXJuCgogICAgICAgICMgVmFsaWRhdGUgZWFjaCBqb2IKICAgICAgICBmb3Igam9iX25hbWUsIGpvYl9jb25maWcgaW4gam9icy5pdGVtcygpOgogICAgICAgICAgICBpWY2VwdCB5YW1sLllBTUxFcnJvciBhcyBlOgogICAgICAgICAgICBzZWxmLmVycm9ycy5hcHBlbmQoZiJ7d29ya2Zsb3dfcGF0aC5uYW1lfTogSW52YWxpZCBZQU1MIC0ge2V9IikKICAgICAgICAgICAgcmV0dXJuCiAgICAgICAgZXhjZXB0IEV4Y2VwdGlvbiBhcyBlOgogICAgICAgICAgICBzZWxmLmVycm9ycy5hcHBlbmQoZiJ7d29ya2Zsb3dfcGF0aC5uYW1lfTogRXJyb3IgcmVhZGluZyBmaWxlIC0ge2V9IikKICAgICAgICAgICAgcmV0dXJuCgogICAgICAgIGlmIGNvbnRlbnQgaXMgTm9uZToKICAgICAgICAgICAgc2VsZi53YXJuaW5ncy5hcHBlbmQoZiJ7d29ya2Zsb3dfcGF0aC5uYW1lfTogRW1wdHkgd29ya2Zsb3cgZmlsZSIpCiAgICAgICAgICAgIHJldHVybgoKICAgICAgICAjIENoZWNrIGlmIHRoaXMgaXMgYSBtZXRhZGF0YSBmaWxlIChub3QgYSB3b3JrZmxvdykKICAgICAgICBpZiAiaWYgbm90IGlzaW5zdGFuY2Uoam9iX2NvbmZpZywgZGljdCk6CiAgICAgICAgICAgICAgICBjb250aW51ZQoKICAgICAgICAgICAgaWYgInJ1bnMtb24iIG5vdCBpbiBqb2JfY29uZmlnOgogICAgICAgICAgICAgICAgc2VsZi5lcnJvcnMuYXBwZW5kKGYie2ZpbGVuYW1lfTogSm9iICd7am9iX25hbWV9JyBtaXNzaW5nICdydW5zLW9uJyIpCgogICAgICAgICAgICBpZiAic3RlcHMiIG5vdCBpbiBqb2JfY29uZmlnOgogICAgICAgICAgICAgICAgc2VsZi5lcnJvcnMuYXBwZW5kKGYie2ZpbGVuYW1lfTogSm9iICd7am9iX25hbWV9JyBtaXNzaW5nICdzdGVwcyciKQoKICAgIGRlZiBfdmFsaWRhdGVfc2VjdXJpdHkoCiAgICAgICAgc2VsZiwgZmlsZW5hbWU6IHN0ciwgcmF3X2NvbnRlbnQ6IHN0ciwgY29udGVudDogRGljdFtzdHIsIEFueV0KICAgICk6CiAgICAgICAgIiIiVmFsaWRhdGUgc2VjdXJpdHkgYmVzdCBwcmFjdGljZXMiIiIKICAgICAgICAjIENoZWNrIGZvciBoYXJkY29kZWQgc2VjcmV0cwogICAgICAgIHNlY3JldF9wYXR0ZXJucyA9IFsKICAgICAgICAgICAgKHIiZ2hwX1thLXpBLVowLTldezM2fSIsICJHaXRIdWIgcGVyc29uYWwgYWNjZXNzIHRva2VuIiksCiAgICAgICAgICAgIChyInNrLVthLXpBLVowLTldezQ4fSIsICJPcGVuQUkgQVBJIGtleSIpLAogICAgICAgICAgICAoCiAgICAgICAgICAgICAgICByIlsnXCJdcGFzc3dvcmRbJ1wiXTpccypbJ1wiXVteJFx7XSIsCiAgICAgICAgICAgICAgICAiSGFyZGNvZGVkIHBhc3N3b3JkIiwKICAgICAgICAgICAgKSwKICAgICAgICAgICAgKHIiWydcIl10b2tlblsnXCJdOlxzKlsnXCJdW14kXHtdIiwgIkhhcmRjb2RlZCB0b2tlbiIpLAogICAgICAgIF0KCiAgICAgICAgZm9yIHBhdHRlcm4sIHNlY3JldF90eXBlIGluIHNlY3JldF9wYXR0ZXJuczoKICAgICAgICAgICAgcmF3X2NvbnRlbnRfcmVkYWN0ZWQgPSByZS5zdWIocGF0dGVybiwgIltSRURBQ1RFRF0iLCByYXdfY29udGVudCwgaWdub3JlY2FzZT1UcnVlKQogICAgICAgICAgICBpZiByYXdfY29udGVudF9yZWRhY3RlZCAhPSByYXdfY29udGVudDoKICAgICAgICAgICAgICAgIHNlbGYuZXJyb3JzLmFwcGVuZCgKICAgICAgICAgICAgICAgICAgICBmIntmaWxlbmFtZX06IFBvdGVudGlhbCB7c2VjcmV0X3R5cGV9IGZvdW5kIC0gdXNlIEdpdEh1YiBzZWNyZXRzIgogICAgICAgICAgICAgICAgKQoKICAgICAgICAjIENoZWNrIGZvciBwdWxsX3JlcXVlc3RfdGFyZ2V0CiAgICAgICAgdHJpZ2dlcnMgPSBjb250ZW50LmdldCgib24iLCB7fSkgb3IgY29udGVudC5nZXQoVHJ1ZSwge30pCiAgICAgICAgaWYgaXNpbnN0YW5jZSh0cmlnZ2VycywgZGljdCkgYW5kICJwdWxsX3JlcXVlc3RfdGFyZ2V0IiBpbiB0cmlnZ2VyczoKICAgICAgICAgICAgc2VsZi53YXJuaW5ncy5hcHBlbmQoCiAgICAgICAgICAgICAgICBmIntmaWxlbmFtZX06IFVzZXMgJ3B1bGxfcmVxdWVzdF90YXJnZXQnIC0gZW5zdXJlIHByb3BlciBzYWZldHkgY2hlY2tzIgogICAgICAgICAgICApCgogICAgICAgICMgQ2hlY2sgcGVybWlzc2lvbnMKICAgICAgICBpZiAicGVybWlzc2lvbnMiIG5vdCBpbiBjb250ZW50OgogICAgICAgICAgICBqb2JzID0gY29udGVudC5nZXQoImpvYnMiLCB7fSkKICAgICAgICAgICAgaGFzX2pvYl9wZXJtaXNzaW9ucyA9IGFueSgKICAgICAgICAgICAgICAgICJwZXJtaXNzaW9ucyIgaW4gam9iCiAgICAgICAgICAgICAgICBmb3Igam9iIGluIGpvYnMudmFsdWVzKCkKIC2ICAgICAgICAgICAgICAgaWYgaXNpbnN0YW5jZShqb2IsIGRpY3QpCiAgICAgICAgICAgICApCiAgICAgICAgICAgIGlmIG5vdCBoYXNfam9iX3Blcm1pc3Npb25zOgogICAgICAgICAgICAgICAgc2VsZi5pbmZvLmFwcGVuZCgKICAgICAgICAgICAgICAgICAgICBmIntmaWxlbmFtZX06IE5vIHBlcm1pc3Npb25zIGRlZmluZWQgKG1heSB1c2UgZGVmYXVsdCkiCiAgICAgICAgICAgICAgICApCgogICAgZGVmIF92YWxpZGF0ZV9iZXN0X3ByYWN0aWNlcyhzZWxmLCBmaWxlbmFtZTogc3RyLCBjb250ZW50OiBEaWN0W3N0ciwgQW55XSk6CiAgICAgICAgIiIiVmFsaWRhdGUgYmVzdCBwcmFjdGljZXMiIiIKICAgICAgICAjIENoZWNrIFB5dGhvbiB2ZXJzaW9ucwogICAgICAgIHJhd19zdHIgPSBzdHIoY29udGVudCkKICAgICAgICBweXRob25fdmVy
-c2lvbnMgPSByZS5maW5kYWxsKHIicHl0aG9uLXZlcnNpb25bJ1wiXT86XHMqWydcIl0/KFxkK1wuXGQrKSIsIHJhd19zdHIpCgogICAgICAgIHN1cHBvcnRlZF92ZXJzaW9ucyA9IFsiMy4xMCIsICIzLjExIiwgIjMuMTIiXQogICAgICAgIGZvciB2ZXJzaW9uIGluIHB5dGhvbl92ZXJzaW9uczoKICAgICAgICAgICAgaWYgdmVyc2lvbiBub3QgaW4gc3VwcG9ydGVkX3ZlcnNpb25zOgogICAgICAgICAgICAgICAgc2VsZi53YXJuaW5ncy5hcHBlbmQoCiAgICAgICAgICAgICAgICAgICAgZiJ7ZmlsZW5hbWV9OiBQeXRob24ge3ZlcnNpb259IG1heSBub3QgYmUgc3VwcG9ydGVkIgogICAgICAgICAgICAgICAgKQoKICAgICAgICAjIENoZWNrIGFjdGlvbiB2ZXJzaW9ucwogICAgICAgIGpvYnMgPSBjb250ZW50LmdldCgiam9icyIsIHt9KQogICAgICAgIGZvciBqb2JfbmFtZSwgam9iX2NvbmZpZyBpbiBqb2JzLml0ZW1zKCk6CiAgICAgICAgICAgIGlmIG5vdCBpc2luc3RhbmNlKGpvYl9jb25maWcsIGRpY3QpOgogICAgICAgICAgICAgICAgY29udGlu
-dWUKCiAgICAgICAgICAgIHN0ZXBzID0gam9iX2NvbmZpZy5nZXQoInN0ZXBzIiwgW10pCiAgICAgICAgICAgIGZvciBzdGVwIGluIHN0ZXBzOgogICAgICAgICAgICAgICAgaWYgbm90IGlzaW5zdGFuY2Uoc3RlcCwgZGljdCk6CiAgICAgICAgICAgICAgICAgICAgY29udGludWUKCiAgICAgICAgICAgICAgICB1c2VzID0gc3RlcC5nZXQoInVzZXMiLCAiIikKICAgICAgICAgICAgICAgIGlmIHVzZXMgYW5kIG5vdCB1c2VzLnN0YXJ0c3dpdGgoIi4vIik6CiAgICAgICAgICAgICAgICAgICAgICAjIENoZWNrIGlmIGFjdGlvbiBpcyBwaW5uZWQKICAgICAgICAgICAgICAgICAgICAgIGlmICJAIiBub3QgaW4gdXNlczoKICAgICAgICAgICAgICAgICAgICAgICAgICBzZWxmLndhcm5pbmdzLmFwcGVuZCgKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZiJ7ZmlsZW5hbWV9OiBVbnBpbm5lZCBhY3Rpb24gaW4gam9iICd7am9iX25hbWV9Jzoge3VzZXN9IgogICAgICAgICAgICAgICAgICAgICAgICAgICApCgogICAgZGVmIF9wcmludF9yZXN1bHRzKHNlbGYpOgogICAgICAgICIiIlByaW50IHZhbGlkYXRpb24gcmVzdWx0cyIiIgogICAgICAgIHByaW50KCJcbiIgKyAiPSIgKiA2MCkKICAgICAgICBwcmludCgi8J+UiiBWYWxpZGF0aW9uIFJlc3VsdHMiikKICAgICAgICBwcmludCgiPSIgKiA2MCkKCiAgICAgICAgaWYgc2VsZi5lcnJvcnM6CiAgICAgICAgICAgIHByaW50KGYiXG7inYwgRXJyb3JzICh7bGVuKHNlbGYuZXJyb3JzKX0pOiIpCiAgICAgICAgICAgIGZvciBlcnJvciBpbiBzZWxmLmVycm9yczoKICAgICAgICAgICAgICAgIHByaW50KGYiICDigKIge2Vycm9yfSIpCgogICAgICAgIGlmIHNlbGYud2FybmluZ3M6CiAgICAgICAgICAgIHByaW50KGYiXG7imqDvuI8gIFdhcm5pbmdzICh7bGVuKHNlbGYud2FybmluZ3MpfSk6IikKICAgICAgICAgICAgZm9yIHdhcm5pbmcgaW4gc2VsZi53YXJuaW5nczoKICAgICAgICAgICAgICAgIHByaW50KGYiICDigKIge3dhcm5pbmd9IikKCiAgICAgICAgaWYgc2VsZi5pbmZvOgogICAgICAgICAgICBwcmludChmIlxu4oS577iPICBJbmZvICh7bGVuKHNlbGYuaW5mbyl9KToiKQogICAgICAgICAgICBmb3IgaW5mbyBpbiBzZWxmLmluZm86CiAgICAgICAgICAgICAgICBwcmludChmIiAg4oCiIHtpbmZvfSIpCgogICAgICAgIGlmIG5vdCBzZWxmLmVycm9ycyBhbmQgbm90IHNlbGYud2FybmluZ3M6CiAgICAgICAgICAgIHByaW50KCJcbuKchSBBbGwgdmFsaWRhdGlvbnMgcGFzc2VkISIpCgogICAgICAgIHByaW50KCJcbiIgKyAiPSIgKiA2MCkKCgpkZWYgbWFpbigpOgogICAgIiIiTWFpbiBlbnRyeSBwb2ludCIiIgogICAgcGFyc2VyID0gYXJncGFyc2UuQXJndW1lbnRQYXJzZXIoCiAgICAgICAgZGVzY3JpcHRpb249IlZhbGlkYXRlIEdpdEh1YiB3b3JrZmxvdyBmaWxlcyIsCiAgICAgICAgZm9ybWF0dGVyX2NsYXNzPWFyZ3BhcnNlLlJhd0Rlc2NyaXB0aW9uSGVscEZvcm1h
-dHRlciwKICAgICkKICAgIHBhcnNlci5hZGRfYXJndW1lbnQoCiAgICAgICAgCi0td29ya2Zsb3ciLAogICAgICAgIGhlbHA9IlNwZWNpZmljIHdvcmtmbG93IGZpbGUgdG8gdmFsaWRhdGUgKGUuZy4sIGNpLnltbCkiLAogICAgKQogICAgcGFyc2VyLmFkZF9hcmd1bWVudCgKICAgICAgICAiLS1zZWN1cml0eS1vbmx5IiwKICAgICAgICBhY3Rpb249InN0b3JlX3RydWUiLAogICAgICAgIGhlbHA9Ik9ubHkgcnVuIHNlY3VyaXR5IGNoZWNrcyIsCiAgICApCgogICAgYXJncyA9IHBhcnNlci5wYXJzZV9hcmdzKCkKCiAgICAjIEZpbmQgcmVwb3NpdG9yeSByb290CiAgICByZXBvX3Jvb3QgPSBQYXRoKF9fZmlsZV9fKS5wYXJlbnQucGFyZW50CiAgICBpZiBub3QgKHJlcG9fcm9vdCAvICIuZ2l0aHViIiAvICJ3b3JrZmxvd3MiKS5leGlzdHMoKToKICAgICAgICBwcmludCgi4p2MIEVycm9yOiAuZ2l0aHViL3dvcmtmbG93cyBkaXJlY3Rvcnkgbm90IGZvdW5kIikKICAgICAgICBwcmludChmIiAgIFNlYXJjaGVkIGluOiB7cmVwb19yb290fSIpCiAgICAgICAgcmV0dXJuIDEKCiAgICB2YWxpZGF0b3IgPSBXb3JrZmxvd1ZhbGlkYXRvcihyZXBvX3Jvb3QpCiAgICBzdWNjZXNzID0gdmFsaWRhdG9yLnZhbGlkYXRlX2FsbCh3b3JrZmxvd19uYW1lPWFyZ3Mud29ya2Zsb3cpCgogICAgcmV0dXJuIDAgaWYgc3VjY2VzcyBlbHNlIDEKCgppZiBfX25hbWVfXyA9PSAiX19tYWluX18iOgogICAgc3lzLmV4aXQobWFpmainKQo=
+#!/usr/bin/env python3
+"""
+Workflow Validation Script
+
+This script validates GitHub workflow files for syntax, security, and best practices.
+Can be run locally or in CI to ensure workflows are properly configured.
+
+Usage:
+    python scripts/validate_workflows.py
+    python scripts/validate_workflows.py --workflow ci.yml
+    python scripts/validate_workflows.py --security-only
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class WorkflowValidator:
+    """Validates GitHub workflow files"""
+
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = repo_root
+        self.workflows_dir = repo_root / ".github" / "workflows"
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+        self.info: list[str] = []
+
+    def validate_all(self, workflow_name: str | None = None) -> bool:
+        """
+        Validate all workflows or a specific workflow.
+
+        Args:
+            workflow_name: Optional specific workflow to validate
+
+        Returns:
+            True if validation passes, False otherwise
+        """
+        print("🔍 GitHub Workflow Validator")
+        print("=" * 60)
+
+        if workflow_name:
+            workflow_file = self.workflows_dir / workflow_name
+            if not workflow_file.exists():
+                self.errors.append(f"Workflow file not found: {workflow_name}")
+                return False
+            workflows = [workflow_file]
+        else:
+            workflows = self._get_workflow_files()
+
+        if not workflows:
+            self.errors.append("No workflow files found")
+            return False
+
+        print(f"📋 Found {len(workflows)} workflow file(s) to validate\n")
+
+        for workflow in workflows:
+            self._validate_workflow(workflow)
+
+        self._print_results()
+        return len(self.errors) == 0
+
+    def _get_workflow_files(self) -> list[Path]:
+        """Get all workflow files"""
+        workflows = []
+        for pattern in ["*.yml", "*.yaml"]:
+            workflows.extend(self.workflows_dir.glob(pattern))
+            workflows.extend(self.workflows_dir.glob(f"**/{pattern}"))
+        return sorted(set(workflows))
+
+    def _validate_workflow(self, workflow_path: Path) -> None:
+        """Validate a single workflow file"""
+        print(f"📄 Validating: {workflow_path.relative_to(self.repo_root)}")
+
+        # Check YAML syntax
+        try:
+            with workflow_path.open() as f:
+                raw_content = f.read()
+                f.seek(0)
+                content = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            self.errors.append(f"{workflow_path.name}: Invalid YAML - {e}")
+            return
+        except Exception as e:
+            self.errors.append(f"{workflow_path.name}: Error reading file - {e}")
+            return
+
+        if content is None:
+            self.warnings.append(f"{workflow_path.name}: Empty workflow file")
+            return
+
+        # Check if this is a metadata file (not a workflow)
+        if self._is_metadata_file(workflow_path.name, content):
+            print("  Info: Metadata file (not a workflow) - skipping validation\n")
+            return
+
+        # Validate structure
+        self._validate_structure(workflow_path.name, content)
+
+        # Validate security
+        self._validate_security(workflow_path.name, raw_content, content)
+
+        # Validate best practices
+        self._validate_best_practices(workflow_path.name, content)
+
+        print("  ✓ Validation complete\n")
+
+    def _is_metadata_file(self, filename: str, content: dict[str, Any]) -> bool:  # noqa: ARG002
+        """Check if file is metadata rather than a workflow"""
+        # Check for HF Space metadata indicators
+        if "sdk" in content or "emoji" in content or "colorFrom" in content:
+            return True
+
+        # Files that contain 'title' but no 'jobs' are likely metadata
+        return "title" in content and "jobs" not in content and "on" not in content
+
+    def _validate_structure(self, filename: str, content: dict[str, Any]) -> None:
+        """Validate workflow structure"""
+        # Check required fields
+        if "name" not in content:
+            self.warnings.append(f"{filename}: Missing 'name' field")
+
+        # Check for trigger (on: or True for YAML boolean)
+        has_trigger = "on" in content or True in content
+        if not has_trigger:
+            self.errors.append(f"{filename}: Missing trigger ('on' field)")
+
+        if "jobs" not in content:
+            self.errors.append(f"{filename}: Missing 'jobs' definition")
+            return
+
+        # Validate jobs
+        jobs = content.get("jobs", {})
+        if not isinstance(jobs, dict):
+            self.errors.append(f"{filename}: 'jobs' must be a dictionary")
+            return
+
+        if not jobs:
+            self.errors.append(f"{filename}: No jobs defined")
+            return
+
+        # Validate each job
+        for job_name, job_config in jobs.items():
+            if not isinstance(job_config, dict):
+                continue
+
+            if "runs-on" not in job_config:
+                self.errors.append(f"{filename}: Job '{job_name}' missing 'runs-on'")
+
+            if "steps" not in job_config:
+                self.errors.append(f"{filename}: Job '{job_name}' missing 'steps'")
+
+    def _validate_security(
+        self, filename: str, raw_content: str, content: dict[str, Any]
+    ) -> None:
+        """Validate security best practices"""
+        # Check for hardcoded secrets
+        secret_patterns = [
+            (r"ghp_[a-zA-Z0-9]{36}", "GitHub personal access token"),
+            (r"sk-[a-zA-Z0-9]{48}", "OpenAI API key"),
+            (
+                r"['\"]password['\"]:\s*['\"][^$\{]",
+                "Hardcoded password",
+            ),
+            (r"['\"]token['\"]:\s*['\"][^$\{]", "Hardcoded token"),
+        ]
+
+        for pattern, secret_type in secret_patterns:
+            redacted_content = re.sub(
+                pattern, "[REDACTED]", raw_content, flags=re.IGNORECASE
+            )
+            if redacted_content != raw_content:
+                self.errors.append(
+                    f"{filename}: Potential {secret_type} found - use GitHub secrets"
+                )
+
+        # Check for pull_request_target
+        triggers = content.get("on", {}) or content.get(True, {})
+        if isinstance(triggers, dict) and "pull_request_target" in triggers:
+            self.warnings.append(
+                f"{filename}: Uses 'pull_request_target' - ensure proper safety checks"
+            )
+
+        # Check permissions
+        if "permissions" not in content:
+            jobs = content.get("jobs", {})
+            has_job_permissions = any(
+                "permissions" in job
+                for job in jobs.values()
+                if isinstance(job, dict)
+            )
+            if not has_job_permissions:
+                self.info.append(
+                    f"{filename}: No permissions defined (may use default)"
+                )
+
+    def _validate_best_practices(self, filename: str, content: dict[str, Any]) -> None:
+        """Validate best practices"""
+        # Check Python versions
+        raw_str = str(content)
+        python_versions = re.findall(
+            r"python-version['\"]?:\s*['\"]?(\d+\.\d+)", raw_str
+        )
+
+        supported_versions = ["3.10", "3.11", "3.12"]
+        for version in python_versions:
+            if version not in supported_versions:
+                self.warnings.append(
+                    f"{filename}: Python {version} may not be supported"
+                )
+
+        # Check action versions
+        jobs = content.get("jobs", {})
+        for job_name, job_config in jobs.items():
+            if not isinstance(job_config, dict):
+                continue
+
+            steps = job_config.get("steps", [])
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+
+                uses = step.get("uses", "")
+                if uses and not uses.startswith("./") and "@" not in uses:
+                    self.warnings.append(
+                        f"{filename}: Unpinned action in job '{job_name}': {uses}"
+                    )
+
+    def _print_results(self) -> None:
+        """Print validation results"""
+        print("\n" + "=" * 60)
+        print("📊 Validation Results")
+        print("=" * 60)
+
+        if self.errors:
+            print(f"\n❌ Errors ({len(self.errors)}):")
+            for error in self.errors:
+                print(f"  • {error}")
+
+        if self.warnings:
+            print(f"\n⚠️  Warnings ({len(self.warnings)}):")
+            for warning in self.warnings:
+                print(f"  • {warning}")
+
+        if self.info:
+            print(f"\nInfo ({len(self.info)}):")
+            for info in self.info:
+                print(f"  • {info}")
+
+        if not self.errors and not self.warnings:
+            print("\n✅ All validations passed!")
+
+        print("\n" + "=" * 60)
+
+
+def main() -> int:
+    """Main entry point"""
+    parser = argparse.ArgumentParser(
+        description="Validate GitHub workflow files",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--workflow",
+        help="Specific workflow file to validate (e.g., ci.yml)",
+    )
+    parser.add_argument(
+        "--security-only",
+        action="store_true",
+        help="Only run security checks",
+    )
+
+    args = parser.parse_args()
+
+    # Find repository root
+    repo_root = Path(__file__).parent.parent
+    if not (repo_root / ".github" / "workflows").exists():
+        print("❌ Error: .github/workflows directory not found")
+        print(f"   Searched in: {repo_root}")
+        return 1
+
+    validator = WorkflowValidator(repo_root)
+    success = validator.validate_all(workflow_name=args.workflow)
+
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_workflows.py
+++ b/scripts/validate_workflows.py
@@ -24,6 +24,17 @@ class WorkflowValidator:
     """Validates GitHub workflow files"""
 
     def __init__(self, repo_root: Path) -> None:
+        """
+        Create a WorkflowValidator bound to a repository root path and initialize result collectors.
+        
+        Parameters:
+            repo_root (Path): Root directory of the repository; the workflows directory is resolved to
+                "<repo_root>/.github/workflows".
+        
+        Description:
+            Sets self.repo_root, computes self.workflows_dir, and initializes three lists used to
+            accumulate validation messages: self.errors, self.warnings, and self.info.
+        """
         self.repo_root = repo_root
         self.workflows_dir = repo_root / ".github" / "workflows"
         self.errors: list[str] = []
@@ -32,13 +43,13 @@ class WorkflowValidator:
 
     def validate_all(self, workflow_name: str | None = None) -> bool:
         """
-        Validate all workflows or a specific workflow.
-
-        Args:
-            workflow_name: Optional specific workflow to validate
-
+        Validate either a single workflow file or all workflows in the repository workflows directory.
+        
+        Parameters:
+            workflow_name (str | None): Optional filename of a single workflow to validate; if omitted, all files in `.github/workflows` are validated.
+        
         Returns:
-            True if validation passes, False otherwise
+            bool: `True` if no validation errors were recorded, `False` otherwise.
         """
         print("🔍 GitHub Workflow Validator")
         print("=" * 60)
@@ -65,7 +76,14 @@ class WorkflowValidator:
         return len(self.errors) == 0
 
     def _get_workflow_files(self) -> list[Path]:
-        """Get all workflow files"""
+        """
+        Collect all GitHub Actions workflow files in the workflows directory and its subdirectories.
+        
+        Searches for files with extensions `*.yml` and `*.yaml`, deduplicates matches, and returns them in a sorted list.
+        
+        Returns:
+            list[Path]: Sorted list of unique Path objects pointing to workflow files under the workflows directory.
+        """
         workflows = []
         for pattern in ["*.yml", "*.yaml"]:
             workflows.extend(self.workflows_dir.glob(pattern))
@@ -73,7 +91,19 @@ class WorkflowValidator:
         return sorted(set(workflows))
 
     def _validate_workflow(self, workflow_path: Path) -> None:
-        """Validate a single workflow file"""
+        """
+        Validate a single GitHub Actions workflow file and record any findings.
+        
+        Parses the file at `workflow_path`, records YAML syntax or file-read errors to
+        `self.errors`, records an empty-file condition to `self.warnings`, and skips
+        non-workflow metadata files. For valid workflow content, runs structural,
+        security, and best-practice validations which append messages to
+        `self.errors`, `self.warnings`, or `self.info` as appropriate. Progress and
+        result lines are printed to stdout for the file being validated.
+        
+        Parameters:
+            workflow_path (Path): Path to the workflow file to validate.
+        """
         print(f"📄 Validating: {workflow_path.relative_to(self.repo_root)}")
 
         # Check YAML syntax
@@ -110,7 +140,12 @@ class WorkflowValidator:
         print("  ✓ Validation complete\n")
 
     def _is_metadata_file(self, filename: str, content: dict[str, Any]) -> bool:  # noqa: ARG002
-        """Check if file is metadata rather than a workflow"""
+        """
+        Determine whether the parsed YAML represents repository metadata rather than a GitHub Actions workflow.
+        
+        Returns:
+            bool: `True` if the content appears to be metadata (contains keys such as `sdk`, `emoji`, or `colorFrom`, or has a `title` key without `jobs` and without `on`), `False` otherwise.
+        """
         # Check for HF Space metadata indicators
         if "sdk" in content or "emoji" in content or "colorFrom" in content:
             return True
@@ -119,7 +154,21 @@ class WorkflowValidator:
         return "title" in content and "jobs" not in content and "on" not in content
 
     def _validate_structure(self, filename: str, content: dict[str, Any]) -> None:
-        """Validate workflow structure"""
+        """
+        Validate the structural correctness of a GitHub Actions workflow file.
+        
+        Performs checks for required top-level keys and job-level fields and records findings on the instance result lists:
+        - Warns when the workflow `name` is missing.
+        - Errors when a trigger (`on`) is not present, when `jobs` is missing, not a mapping, or empty.
+        - For each job mapping, errors when `runs-on` or `steps` are missing.
+        
+        Parameters:
+            filename (str): Relative workflow filename used when reporting issues.
+            content (dict[str, Any]): Parsed YAML content of the workflow.
+        
+        Side effects:
+            Appends human-readable messages to self.errors and self.warnings.
+        """
         # Check required fields
         if "name" not in content:
             self.warnings.append(f"{filename}: Missing 'name' field")
@@ -157,7 +206,19 @@ class WorkflowValidator:
     def _validate_security(
         self, filename: str, raw_content: str, content: dict[str, Any]
     ) -> None:
-        """Validate security best practices"""
+        """
+        Validate security-related issues in a workflow's content.
+        
+        Performs three checks and records findings by appending messages to the instance result lists:
+        - Detects potential hardcoded secrets in the raw file text and appends an error for each match.
+        - Warns if the workflow declares a `pull_request_target` trigger.
+        - Records an informational message if neither the workflow nor any job defines `permissions`.
+        
+        Parameters:
+            filename (str): Workflow filename used in reported messages (typically relative to the repo root).
+            raw_content (str): Raw YAML file content used for pattern scanning.
+            content (dict[str, Any]): Parsed YAML content used for structural checks.
+        """
         # Check for hardcoded secrets
         secret_patterns = [
             (r"ghp_[a-zA-Z0-9]{36}", "GitHub personal access token"),
@@ -199,7 +260,15 @@ class WorkflowValidator:
                 )
 
     def _validate_best_practices(self, filename: str, content: dict[str, Any]) -> None:
-        """Validate best practices"""
+        """
+        Validate repository workflow best practices.
+        
+        Checks workflow Python version declarations against a supported version list and records a warning for any declared version not in that list; also detects steps that reference actions without a pinned ref (no '@' and not a local path) and records a warning for each unpinned action.
+        
+        Parameters:
+            filename (str): Workflow file name or relative path used in reported messages.
+            content (dict[str, Any]): Parsed YAML content of the workflow.
+        """
         # Check Python versions
         raw_str = str(content)
         python_versions = re.findall(
@@ -231,7 +300,11 @@ class WorkflowValidator:
                     )
 
     def _print_results(self) -> None:
-        """Print validation results"""
+        """
+        Print a formatted summary of collected validation messages to standard output.
+        
+        Displays errors, warnings, and informational messages from the validator instance in separate, labeled sections with counts. If there are no errors or warnings, prints a success message. This method has no return value and writes output directly to stdout.
+        """
         print("\n" + "=" * 60)
         print("📊 Validation Results")
         print("=" * 60)
@@ -258,7 +331,14 @@ class WorkflowValidator:
 
 
 def main() -> int:
-    """Main entry point"""
+    """
+    Validate GitHub Actions workflow files in the repository and return an exit code.
+    
+    Attempts to locate the repository's .github/workflows directory, runs validations using WorkflowValidator (optionally for a single workflow when --workflow is provided), and returns an OS-style exit code.
+    
+    Returns:
+        int: 0 if no validation errors were found, 1 if the workflows directory is missing or validation failed.
+    """
     parser = argparse.ArgumentParser(
         description="Validate GitHub workflow files",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,12 +1,35 @@
-"""Utility modules for CodeTuneStudio."""
+"""Utility modules for CodeTuneStudio.
+
+Database-backed symbols are loaded lazily so subpackages such as
+``utils.plugins`` remain importable in lightweight analysis environments where
+Flask database dependencies are not installed.
+"""
 
 from utils.config_validator import validate_config
-from utils.database import TrainingConfig, TrainingMetric, db, init_db
 
 __all__ = [
-    "validate_config",
-    "init_db",
     "TrainingConfig",
     "TrainingMetric",
     "db",
+    "init_db",
+    "validate_config",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name in {"TrainingConfig", "TrainingMetric", "db", "init_db"}:
+        from utils.database import (  # noqa: PLC0415
+            TrainingConfig,
+            TrainingMetric,
+            db,
+            init_db,
+        )
+
+        return {
+            "TrainingConfig": TrainingConfig,
+            "TrainingMetric": TrainingMetric,
+            "db": db,
+            "init_db": init_db,
+        }[name]
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -17,6 +17,18 @@ __all__ = [
 
 
 def __getattr__(name: str) -> object:
+    """
+    Lazily resolve and return selected database-backed attributes when accessed on the module.
+    
+    Parameters:
+        name (str): Attribute name requested from the module; supported values are "TrainingConfig", "TrainingMetric", "db", and "init_db".
+    
+    Returns:
+        object: The requested attribute object corresponding to name.
+    
+    Raises:
+        AttributeError: If name is not one of the supported attributes.
+    """
     if name in {"TrainingConfig", "TrainingMetric", "db", "init_db"}:
         from utils.database import (  # noqa: PLC0415
             TrainingConfig,


### PR DESCRIPTION
### Motivation
- Several files used by static analysis and unit tests were corrupted/encoded and prevented import, linting, and test execution, so restore executable versions to enable local validation and CI checks. 
- Make plugin modules importable in lightweight environments where optional SDKs (`openai`, `anthropic`) or DB dependencies may be missing, to allow static analysis and selective tests to run. 
- Harden the workflow validation script to redact potential secrets and be usable in local/static contexts.

### Description
- Restored parser package sources with language detection, Python AST parsing, optional JavaScript parsing, JSON serialization, and result dataclasses in `core/parser/engine.py` and `core/parser/types.py`, and exported API in `core/parser/__init__.py`. 
- Added smoke tests and a package marker (`core/parser/tests/test_parser.py`, `core/parser/tests/__init__.py`) to exercise the parsing pipeline. 
- Recovered Anthropic plugin `plugins/anthropic_code_suggester.py` to a runnable implementation with API-key fallback and safe error paths. 
- Added an import fallback for `openai` in `plugins/openai_code_analyzer.py` that injects a noop client type into `sys.modules` so the module can be imported when the SDK is absent. 
- Restored and improved `scripts/validate_workflows.py` with YAML parsing, secret-redaction checks, permission checks, and best-practice validations. 
- Made `utils` DB exports lazy via `__getattr__` in `utils/__init__.py` so importing plugin modules does not require Flask/DB packages during static analysis. 
- Cleaned up lint warnings and added targeted fixes to satisfy `ruff` checks on modified files.

### Testing
- Ran a byte-compile check across Python files with `python - <<'PY' ... py_compile.compile(..., doraise=True) ... PY` and found no syntax/compile errors. (succeeded) 
- Ran `ruff check` on the touched files (`core/parser`, `plugins/anthropic_code_suggester.py`, `plugins/openai_code_analyzer.py`, `utils/__init__.py`, `scripts/validate_workflows.py`) and fixed lint issues reported by `ruff` (succeeded). 
- Executed targeted unit tests with `pytest -q tests/test_anthropic_code_suggester.py core/parser/tests/test_parser.py` and these tests passed (10 passed). 
- Attempting full `pytest -q` collection is blocked by missing optional environment packages (`streamlit`, `flask`, `PyYAML`), so full-suite collection was not completed in this environment (blocked). 
- Note: `tests/test_openai_code_analyzer.py` had a stale expectation that invalid inputs should still call the API; the implementation was changed to return a validation error instead, causing a behavioral-test mismatch that should be reconciled (test update or deliberate behavior change) before declaring full CI green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a01612ed4833285ee5a1ba23160a8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code parsing pipeline with language detection (Python/JavaScript/Bash) and JSON serialization
  * Workflow validation CLI with security and best-practice checks

* **Bug Fixes**
  * Improved handling and clearer errors when optional AI dependencies are absent
  * Tighter input validation and error reporting in AI plugins

* **Refactor**
  * Lazily load heavy modules to avoid eager imports; updated public export declarations and type annotations

* **Tests**
  * Added/updated parser tests for detection, success, and failure cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->